### PR TITLE
Add support for https_proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,16 +159,27 @@ or alternatively set variable in `.npmrc`
 
 ## Download behind proxy
 
-In order to be able to download binaries when you're behind a proxy it will be enough to set http_proxy environment variable.
+In order to be able to download binaries when you're behind a proxy it will be enough to set the `http_proxy` environment
+variable. The `https_proxy` environment variable is supported as well, should the mirror be using the HTTPS protocol.
+
+Both support proxies using plain HTTP or HTTPS.
 
 **Example:**
 ```shell
 export http_proxy=http://mycompanyproxy.com:PORT
+export https_proxy=http://mycompanyproxy.com:PORT
+
+export http_proxy=https://encryptedcompanyproxy.com:PORT
+export https_proxy=https://encryptedcompanyproxy.com:PORT
 ```
 
 **Behind authenticated proxy:**
 ```shell
 export http_proxy=http://user:password@mycompanyproxy.com:PORT
+export https_proxy=http://user:password@mycompanyproxy.com:PORT
+
+export http_proxy=https://user:password@encryptedcompanyproxy.com:PORT
+export https_proxy=https://user:password@encryptedcompanyproxy.com:PORT
 ```
 
 ## License

--- a/src/config.js
+++ b/src/config.js
@@ -67,7 +67,12 @@ function getScannerParams(basePath, params = {}) {
  *  - httpOptions, if proxy
  */
 function getExecutableParams(params = {}) {
-  const config = {};
+  const config = {
+    httpOptions: {
+      httpRequestOptions: {},
+      httpsRequestOptions: {},
+    },
+  };
   const env = process.env;
 
   const platformBinariesVersion =
@@ -91,15 +96,21 @@ function getExecutableParams(params = {}) {
     SONAR_SCANNER_MIRROR;
   const fileName = (config.fileName =
     'sonar-scanner-cli-' + platformBinariesVersion + '-' + targetOS + '.zip');
-  config.downloadUrl = new URL(fileName, baseUrl).href;
+  const finalUrl = new URL(fileName, baseUrl);
+  config.downloadUrl = finalUrl.href;
 
-  const proxy = process.env.http_proxy;
+  let proxy = '';
+  if (typeof process.env.http_proxy === 'string') {
+    proxy = process.env.http_proxy;
+  }
+  // Use https_proxy when available
+  if (typeof process.env.https_proxy === 'string' && finalUrl.protocol === 'https:') {
+    proxy = process.env.https_proxy;
+  }
   if (proxy && proxy !== '') {
     const proxyAgent = new HttpsProxyAgent(proxy);
-    config.httpOptions = {
-      httpRequestOptions: { agent: proxyAgent },
-      httpsRequestOptions: { agent: proxyAgent },
-    };
+    config.httpOptions.httpRequestOptions.agent = proxyAgent;
+    config.httpOptions.httpsRequestOptions.agent = proxyAgent;
   }
   log(`Executable parameters built:`);
   log(config);


### PR DESCRIPTION
In some environments, proxies for Internet resources using HTTPS may be different from proxies for Internet resources using plain HTTP. Alternatively, to enforce HTTPS communication with third-party resources for compliance, outgoing Internet access may be blocked and only `https_proxy` be set.

This PR adds support for the `https_proxy` environment variable, as well as documentation on usage and unit tests.