### PR TITLE
Add support for Basic authentication on SonarScanner mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,15 @@ or alternatively set variable in `.npmrc`
     sonar_scanner_version=3.2.0.1227
 ```
 
+For mirrors using Basic HTTP authentication (e.g. Sonatype Nexus 3 `raw-proxy`, Artifactory with `artifactory-cache-proxy`), simply specify the username and password
+as part of the URL:
+
+```shell
+export SONAR_SCANNER_MIRROR=https://username:password@repo.example.com/mirrors/sonar-scanner/
+```
+
+Mirror authentication is supported as well, see below.
+
 ## Specifying the cache folder
 
 By default, the scanner binaries are cached into `$HOME/.sonar/native-sonar-scanner` folder.

--- a/README.md
+++ b/README.md
@@ -159,16 +159,27 @@ or alternatively set variable in `.npmrc`
 
 ## Download behind proxy
 
-In order to be able to download binaries when you're behind a proxy it will be enough to set http_proxy environment variable.
+In order to be able to download binaries when you're behind a proxy it will be enough to set the `http_proxy` environment
+variable. The `https_proxy` environment variable is supported as well, should the mirror be using the HTTPS protocol.
+
+Both support proxies using plain HTTP or HTTPS.
 
 **Example:**
 ```shell
 export http_proxy=http://mycompanyproxy.com:PORT
+export https_proxy=http://mycompanyproxy.com:PORT
+
+export http_proxy=https://encryptedcompanyproxy.com:PORT
+export https_proxy=https://encryptedcompanyproxy.com:PORT
 ```
 
 **Behind authenticated proxy:**
 ```shell
 export http_proxy=http://user:password@mycompanyproxy.com:PORT
+export https_proxy=http://user:password@mycompanyproxy.com:PORT
+
+export http_proxy=https://user:password@encryptedcompanyproxy.com:PORT
+export https_proxy=https://user:password@encryptedcompanyproxy.com:PORT
 ```
 
 ## License

--- a/src/config.js
+++ b/src/config.js
@@ -67,7 +67,12 @@ function getScannerParams(basePath, params = {}) {
  *  - httpOptions, if proxy
  */
 function getExecutableParams(params = {}) {
-  const config = {};
+  const config = {
+    httpOptions: {
+      httpRequestOptions: {},
+      httpsRequestOptions: {},
+    },
+  };
   const env = process.env;
 
   const platformBinariesVersion =
@@ -91,15 +96,21 @@ function getExecutableParams(params = {}) {
     SONAR_SCANNER_MIRROR;
   const fileName = (config.fileName =
     'sonar-scanner-cli-' + platformBinariesVersion + '-' + targetOS + '.zip');
-  config.downloadUrl = new URL(fileName, baseUrl).href;
+  const finalUrl = new URL(fileName, baseUrl);
+  config.downloadUrl = finalUrl.href;
 
-  const proxy = process.env.http_proxy;
+  let proxy = '';
+  if (typeof process.env.http_proxy === 'string') {
+    proxy = process.env.http_proxy;
+  }
+  // Use https_proxy when available
+  if (typeof process.env.https_proxy === 'string' && finalUrl.protocol === 'https:') {
+    proxy = process.env.https_proxy;
+  }
   if (proxy && proxy !== '') {
     const proxyAgent = new HttpsProxyAgent(proxy);
-    config.httpOptions = {
-      httpRequestOptions: { agent: proxyAgent },
-      httpsRequestOptions: { agent: proxyAgent },
-    };
+    config.httpOptions.httpRequestOptions.agent = proxyAgent;
+    config.httpOptions.httpsRequestOptions.agent = proxyAgent;
   }
   log(`Executable parameters built:`);
   log(config);

--- a/src/config.js
+++ b/src/config.js
@@ -69,6 +69,7 @@ function getScannerParams(basePath, params = {}) {
 function getExecutableParams(params = {}) {
   const config = {
     httpOptions: {
+      headers: {},
       httpRequestOptions: {},
       httpsRequestOptions: {},
     },
@@ -111,6 +112,12 @@ function getExecutableParams(params = {}) {
     const proxyAgent = new HttpsProxyAgent(proxy);
     config.httpOptions.httpRequestOptions.agent = proxyAgent;
     config.httpOptions.httpsRequestOptions.agent = proxyAgent;
+  }
+
+  if (finalUrl.username !== '' || finalUrl.password !== '') {
+    const authHeader =
+      'Basic ' + Buffer.from(finalUrl.username + ':' + finalUrl.password).toString('base64');
+    config.httpOptions.headers['Authorization'] = authHeader;
   }
   log(`Executable parameters built:`);
   log(config);

--- a/test/unit/config.test.js
+++ b/test/unit/config.test.js
@@ -311,6 +311,7 @@ describe('config', function () {
         targetOS,
         downloadUrl: new URL(fileName, SONAR_SCANNER_MIRROR).href,
         httpOptions: {
+          headers: {},
           httpRequestOptions: {},
           httpsRequestOptions: {},
         },
@@ -371,6 +372,15 @@ describe('config', function () {
       assert.equal(config.httpOptions.httpRequestOptions.agent.proxy.hostname, 'httpproxy');
       assert.equal(config.httpOptions.httpRequestOptions.agent.proxy.port, 3128);
       assert.equal(config.httpOptions.httpRequestOptions.agent.proxy.protocol, 'http:');
+    });
+
+    it('should consume and preserve username and password for sonar-scanner mirror server', function () {
+      process.env = {};
+      const config = getExecutableParams({
+        baseUrl: 'https://user:password@example.com/sonarqube-repository/',
+      });
+      assert.exists(config.httpOptions.headers['Authorization']);
+      assert.equal(config.httpOptions.headers['Authorization'], 'Basic dXNlcjpwYXNzd29yZA==');
     });
   });
 });


### PR DESCRIPTION
In some environments, it may be required that all artifacts used in a build be stored in a Nexus, Artifactory or similar repository for compliance reasons, and that this mirror enforces authentication.

Ordinary `http_proxy` support is not enough in this case and the existing mirror support does not preserve authentication. This PR adds support for using separate credentials for the mirror. It requires #43 to be merged first, as it bases on this work.