### PR TITLE
Update follow-redirects to 1.15.6

### DIFF
--- a/tools/orchestrator/package-lock.json
+++ b/tools/orchestrator/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "axios": "^1.6.5",
-        "follow-redirects": "1.15.6",
+        "axios": "^1.6.8",
         "mkdirp": "^1.0.4"
       },
       "devDependencies": {
@@ -44,11 +43,11 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.6.7",
-      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/axios/-/axios-1.6.7.tgz",
-      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "version": "1.6.8",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "dependencies": {
-        "follow-redirects": "^1.15.4",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }

--- a/tools/orchestrator/package-lock.json
+++ b/tools/orchestrator/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.6.5",
+        "follow-redirects": "1.15.6",
         "mkdirp": "^1.0.4"
       },
       "devDependencies": {
@@ -72,9 +73,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "engines": {
         "node": ">=4.0"
       },

--- a/tools/orchestrator/package.json
+++ b/tools/orchestrator/package.json
@@ -16,7 +16,8 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^1.6.5",
-    "mkdirp": "^1.0.4"
+    "mkdirp": "^1.0.4",
+    "follow-redirects": "1.15.6"
   },
   "devDependencies": {
     "@types/mkdirp": "^1.0.2",

--- a/tools/orchestrator/package.json
+++ b/tools/orchestrator/package.json
@@ -15,9 +15,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "axios": "^1.6.5",
-    "mkdirp": "^1.0.4",
-    "follow-redirects": "1.15.6"
+    "axios": "^1.6.8",
+    "mkdirp": "^1.0.4"
   },
   "devDependencies": {
     "@types/mkdirp": "^1.0.2",


### PR DESCRIPTION
Fixes #97 

There is a medium vulneribility in 1.15.4, let us update. We don't use this package explicitly, but only axios relies on it.