### PR TITLE
SCANNPM-14 Handle proxy detection & usage

### DIFF
--- a/src/http-agent.ts
+++ b/src/http-agent.ts
@@ -1,0 +1,33 @@
+/*
+ * sonar-scanner-npm
+ * Copyright (C) 2022-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import { AxiosRequestConfig } from 'axios';
+import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
+
+export function getHttpAgents(
+  proxyUrl?: URL,
+): Pick<AxiosRequestConfig, 'httpAgent' | 'httpsAgent'> {
+  const agents: Pick<AxiosRequestConfig, 'httpAgent' | 'httpsAgent'> = {};
+
+  if (proxyUrl) {
+    agents.httpsAgent = new HttpsProxyAgent({ proxy: proxyUrl.toString() });
+    agents.httpAgent = new HttpProxyAgent({ proxy: proxyUrl.toString() });
+  }
+  return agents;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,65 @@
+/*
+ * sonar-scanner-npm
+ * Copyright (C) 2022-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import { URL } from 'url';
+import { LogLevel, log } from './logging';
+import { ScannerProperties, ScannerProperty } from './types';
+
+export function getProxyUrl(properties: ScannerProperties): URL | undefined {
+  const proxyHost = properties[ScannerProperty.SonarScannerProxyHost];
+  const serverUsesHttps = properties[ScannerProperty.SonarHostUrl].startsWith('https');
+
+  if (proxyHost) {
+    // We assume that the proxy protocol is the same as the endpoint.
+    const protocol = serverUsesHttps ? 'https' : 'http';
+    const proxyPort =
+      properties[ScannerProperty.SonarScannerProxyPort] ?? (serverUsesHttps ? 443 : 80);
+    const proxyUser = properties[ScannerProperty.SonarScannerProxyUser] ?? '';
+    const proxyPassword = properties[ScannerProperty.SonarScannerProxyPassword] ?? '';
+    const proxyUrl = new URL(
+      `${protocol}://${proxyUser}:${proxyPassword}@${proxyHost}:${proxyPort}`,
+    );
+    log(LogLevel.DEBUG, `Detecting proxy: ${proxyUrl}`);
+    return proxyUrl;
+  } else if (
+    properties[ScannerProperty.SonarScannerProxyPort] ||
+    properties[ScannerProperty.SonarScannerProxyUser] ||
+    properties[ScannerProperty.SonarScannerProxyPassword]
+  ) {
+    log(LogLevel.WARN, `Detecting proxy: Incomplete proxy configuration. Proxy host is missing.`);
+  }
+
+  log(LogLevel.DEBUG, `Detecting proxy: No proxy detected'}`);
+  return undefined;
+}
+
+export function proxyUrlToJavaOptions(properties: ScannerProperties): string[] {
+  const proxyUrl = getProxyUrl(properties);
+  if (!proxyUrl) {
+    return [];
+  }
+
+  const protocol = properties[ScannerProperty.SonarHostUrl].startsWith('https') ? 'https' : 'http';
+  return [
+    `-D${protocol}.proxyHost=${proxyUrl.hostname}`,
+    `-D${protocol}.proxyPort=${proxyUrl.port}`,
+    `-D${protocol}.proxyUser=${proxyUrl.username}`,
+    `-D${protocol}.proxyPassword=${proxyUrl.password}`,
+  ];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,11 @@ export enum ScannerProperty {
   SonarScannerSonarCloudURL = 'sonar.scanner.sonarcloudUrl',
   SonarScannerJavaExePath = 'sonar.scanner.javaExePath',
   SonarScannerWasEngineCacheHit = 'sonar.scanner.wasEngineCacheHit',
+  SonarScannerProxyHost = 'sonar.scanner.proxyHost',
+  SonarScannerProxyPort = 'sonar.scanner.proxyPort',
+  SonarScannerProxyUser = 'sonar.scanner.proxyUser',
+  SonarScannerProxyPassword = 'sonar.scanner.proxyPassword',
+  SonarScannerInternalIsSonarCloud = 'sonar.scanner.internal.isSonarCloud',
 }
 
 export type ScannerProperties = {

--- a/test/unit/http-agent.test.ts
+++ b/test/unit/http-agent.test.ts
@@ -1,0 +1,41 @@
+/*
+ * sonar-scanner-npm
+ * Copyright (C) 2022-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
+import { getHttpAgents } from '../../src/http-agent';
+
+describe('http-agent', () => {
+  it('should define proxy url correctly', () => {
+    const proxyUrl = new URL('http://proxy.com');
+
+    const agents = getHttpAgents(proxyUrl);
+    expect(agents.httpAgent).toBeInstanceOf(HttpProxyAgent);
+    expect(agents.httpAgent?.proxy.toString()).toBe(proxyUrl.toString());
+    expect(agents.httpsAgent).toBeInstanceOf(HttpsProxyAgent);
+    expect(agents.httpsAgent?.proxy.toString()).toBe(proxyUrl.toString());
+  });
+
+  it('should not define agents when no proxy is provided', () => {
+    const agents = getHttpAgents();
+    expect(agents.httpAgent).toBeUndefined();
+    expect(agents.httpsAgent).toBeUndefined();
+    expect(agents).toEqual({});
+  });
+});

--- a/test/unit/java.test.ts
+++ b/test/unit/java.test.ts
@@ -18,12 +18,19 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { ServerMock } from './mocks/ServerMock';
-import { fetchServerVersion, getEndpoint } from '../../src/java';
+import { fetchServerVersion } from '../../src/java';
 import { fetch } from '../../src/request';
-import { ScannerProperty } from '../../src/types';
+import { ScannerProperties, ScannerProperty } from '../../src/types';
+import { ServerMock } from './mocks/ServerMock';
+
+jest.mock('../../src/request');
 
 const serverHandler = new ServerMock();
+
+const MOCKED_PROPERTIES: ScannerProperties = {
+  [ScannerProperty.SonarHostUrl]: 'http://sonarqube.com',
+  [ScannerProperty.SonarToken]: 'dummy-token',
+};
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -31,80 +38,12 @@ beforeEach(() => {
 });
 
 describe('java', () => {
-  describe('endpoint should be detected correctly', () => {
-    it('should detect SonarCloud', () => {
-      const expected = {
-        isSonarCloud: true,
-        sonarHostUrl: 'https://sonarcloud.io',
-      };
-
-      // SonarCloud used by default
-      expect(getEndpoint({})).toEqual(expected);
-
-      // Backward-compatible use-case
-      expect(
-        getEndpoint({
-          [ScannerProperty.SonarHostUrl]: 'https://sonarcloud.io',
-        }),
-      ).toEqual(expected);
-
-      // Using www.
-      expect(
-        getEndpoint({
-          [ScannerProperty.SonarHostUrl]: 'https://www.sonarcloud.io',
-        }),
-      ).toEqual(expected);
-
-      // Using trailing slash (ensures trailing slash is dropped)
-      expect(
-        getEndpoint({
-          [ScannerProperty.SonarHostUrl]: 'https://www.sonarcloud.io/',
-        }),
-      ).toEqual(expected);
-    });
-
-    it('should detect SonarCloud with custom URL', () => {
-      const endpoint = getEndpoint({
-        [ScannerProperty.SonarHostUrl]: 'https://sonarcloud.io/',
-        [ScannerProperty.SonarScannerSonarCloudURL]: 'http://that-is-a-sonarcloud-custom-url.com',
-      });
-
-      expect(endpoint).toEqual({
-        isSonarCloud: true,
-        sonarHostUrl: 'http://that-is-a-sonarcloud-custom-url.com',
-      });
-    });
-
-    it('should detect SonarQube', () => {
-      const endpoint = getEndpoint({
-        [ScannerProperty.SonarHostUrl]: 'https://next.sonarqube.com',
-      });
-
-      expect(endpoint).toEqual({
-        isSonarCloud: false,
-        sonarHostUrl: 'https://next.sonarqube.com',
-      });
-    });
-
-    it('should ignore SonarCloud custom URL if sonar host URL does not match sonarcloud', () => {
-      const endpoint = getEndpoint({
-        [ScannerProperty.SonarHostUrl]: 'https://next.sonarqube.com',
-        [ScannerProperty.SonarScannerSonarCloudURL]: 'http://that-is-a-sonarcloud-custom-url.com',
-      });
-
-      expect(endpoint).toEqual({
-        isSonarCloud: false,
-        sonarHostUrl: 'https://next.sonarqube.com',
-      });
-    });
-  });
-
   describe('version should be detected correctly', () => {
     it('the SonarQube version should be fetched correctly when new endpoint does not exist', async () => {
       serverHandler.mockServerErrorResponse();
       serverHandler.mockServerVersionResponse('3.2.2');
 
-      const serverSemver = await fetchServerVersion('http://sonarqube.com', 'dummy-token');
+      const serverSemver = await fetchServerVersion('http://sonarqube.com', MOCKED_PROPERTIES);
       expect(serverSemver.toString()).toEqual('3.2.2');
       expect(fetch).toHaveBeenCalledTimes(2);
     });
@@ -112,7 +51,7 @@ describe('java', () => {
     it('the SonarQube version should be fetched correctly using the new endpoint', async () => {
       serverHandler.mockServerVersionResponse('3.2.1.12313');
 
-      const serverSemver = await fetchServerVersion('http://sonarqube.com', 'dummy-token');
+      const serverSemver = await fetchServerVersion('http://sonarqube.com', MOCKED_PROPERTIES);
       expect(serverSemver.toString()).toEqual('3.2.1');
     });
 
@@ -121,7 +60,7 @@ describe('java', () => {
       serverHandler.mockServerErrorResponse();
 
       expect(async () => {
-        await fetchServerVersion('http://sonarqube.com', 'dummy-token');
+        await fetchServerVersion('http://sonarqube.com', MOCKED_PROPERTIES);
       }).rejects.toBeDefined();
     });
 
@@ -129,7 +68,7 @@ describe('java', () => {
       serverHandler.mockServerVersionResponse('<!DOCTYPE><HTML><BODY>FORBIDDEN</BODY></HTML>');
 
       expect(async () => {
-        await fetchServerVersion('http://sonarqube.com', 'dummy-token');
+        await fetchServerVersion('http://sonarqube.com', MOCKED_PROPERTIES);
       }).rejects.toBeDefined();
     });
   });

--- a/test/unit/proxy.test.ts
+++ b/test/unit/proxy.test.ts
@@ -1,0 +1,127 @@
+/*
+ * sonar-scanner-npm
+ * Copyright (C) 2022-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import { log } from '../../src/logging';
+import { getProxyUrl, proxyUrlToJavaOptions } from '../../src/proxy';
+import { ScannerProperties, ScannerProperty } from '../../src/types';
+
+jest.mock('../../src/logging');
+
+describe('proxy', () => {
+  describe('getProxyUrl', () => {
+    it('should not detect proxy when proxy host is not provided', () => {
+      const properties: ScannerProperties = {
+        [ScannerProperty.SonarHostUrl]: 'http://sq.some-company.com',
+        [ScannerProperty.SonarScannerProxyPort]: '4234',
+        [ScannerProperty.SonarScannerProxyUser]: 'user',
+        [ScannerProperty.SonarScannerProxyPassword]: 'password',
+      };
+      getProxyUrl(properties);
+
+      expect(getProxyUrl(properties)).toBeUndefined();
+      expect(log).toHaveBeenCalledWith(
+        'WARN',
+        `Detecting proxy: Incomplete proxy configuration. Proxy host is missing.`,
+      );
+    });
+
+    it('should detect proxy with only host on http endpoint', () => {
+      const properties: ScannerProperties = {
+        [ScannerProperty.SonarHostUrl]: 'http://sq.some-company.com',
+        [ScannerProperty.SonarScannerProxyHost]: 'some-proxy.io',
+      };
+      getProxyUrl(properties);
+
+      expect(getProxyUrl(properties)?.toString()).toBe('http://some-proxy.io/');
+    });
+
+    it('should detect proxy with only host on https endpoint', () => {
+      const properties: ScannerProperties = {
+        [ScannerProperty.SonarHostUrl]: 'https://sq.some-company.com',
+        [ScannerProperty.SonarScannerProxyHost]: 'some-proxy.io',
+      };
+      getProxyUrl(properties);
+
+      expect(getProxyUrl(properties)?.toString()).toBe('https://some-proxy.io/');
+    });
+
+    it('should detect proxy with host and port', () => {
+      const properties: ScannerProperties = {
+        [ScannerProperty.SonarHostUrl]: 'http://sq.some-company.com',
+        [ScannerProperty.SonarScannerProxyHost]: 'some-proxy.io',
+        [ScannerProperty.SonarScannerProxyPort]: '4234',
+      };
+      getProxyUrl(properties);
+
+      expect(getProxyUrl(properties)?.toString()).toBe('http://some-proxy.io:4234/');
+    });
+
+    it('should detect proxy with host, port and authentication', () => {
+      const properties: ScannerProperties = {
+        [ScannerProperty.SonarHostUrl]: 'http://sq.some-company.com',
+        [ScannerProperty.SonarScannerProxyHost]: 'some-proxy.io',
+        [ScannerProperty.SonarScannerProxyPort]: '4234',
+        [ScannerProperty.SonarScannerProxyUser]: 'user',
+        [ScannerProperty.SonarScannerProxyPassword]: 'password',
+      };
+      getProxyUrl(properties);
+
+      expect(getProxyUrl(properties)?.toString()).toBe('http://user:password@some-proxy.io:4234/');
+    });
+  });
+
+  describe('proxyUrlToJavaOptions', () => {
+    it('should return empty array when no proxy', () => {
+      const options = proxyUrlToJavaOptions({
+        [ScannerProperty.SonarHostUrl]: 'http://sq.some-company.com',
+      });
+      expect(options).toEqual([]);
+    });
+
+    it('should return java options for http proxy', () => {
+      const options = proxyUrlToJavaOptions({
+        [ScannerProperty.SonarHostUrl]: 'http://sq.some-company.com',
+        [ScannerProperty.SonarScannerProxyHost]: 'some-proxy.io',
+        [ScannerProperty.SonarScannerProxyPort]: '4234',
+      });
+      expect(options).toEqual([
+        '-Dhttp.proxyHost=some-proxy.io',
+        '-Dhttp.proxyPort=4234',
+        '-Dhttp.proxyUser=',
+        '-Dhttp.proxyPassword=',
+      ]);
+    });
+
+    it('should return java options for https proxy', () => {
+      const options = proxyUrlToJavaOptions({
+        [ScannerProperty.SonarHostUrl]: 'https://sq.some-company.com',
+        [ScannerProperty.SonarScannerProxyHost]: 'some-proxy.io',
+        [ScannerProperty.SonarScannerProxyPort]: '4234',
+        [ScannerProperty.SonarScannerProxyUser]: 'user',
+        [ScannerProperty.SonarScannerProxyPassword]: 'password',
+      });
+      expect(options).toEqual([
+        '-Dhttps.proxyHost=some-proxy.io',
+        '-Dhttps.proxyPort=4234',
+        '-Dhttps.proxyUser=user',
+        '-Dhttps.proxyPassword=password',
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds the ability to detect user-provided proxy configuration and creates http(s) agents passed to axios that will handle the proxy connection. 

Code is fully covered, but we'll need to do another validation at the end when we have the full flow working 