### PR TITLE
NPMSCAN-X Multi-fix bundle

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,7 +17,6 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import path from 'path';
 import { ScannerProperty } from './types';
 
 export const SCANNER_BOOTSTRAPPER_NAME = 'ScannerNpm';
@@ -31,7 +30,7 @@ export const SONARCLOUD_ENV_REGEX =
 
 export const SONARCLOUD_PRODUCTION_URL = 'https://sonarcloud.io';
 
-export const SONARQUBE_JRE_PROVISIONING_MIN_VERSION = '10.5';
+export const SONARQUBE_JRE_PROVISIONING_MIN_VERSION = '10.6';
 
 export const SONAR_DIR_DEFAULT = '.sonar';
 

--- a/src/java.ts
+++ b/src/java.ts
@@ -33,9 +33,9 @@ import {
   getCacheFileLocation,
   validateChecksum,
 } from './file';
-import { log, LogLevel } from './logging';
+import { LogLevel, log } from './logging';
 import { download, fetch } from './request';
-import { PlatformInfo, ScannerProperties, ScannerProperty } from './types';
+import { ScannerProperties, ScannerProperty } from './types';
 
 export async function fetchServerVersion(): Promise<SemVer> {
   let version: SemVer | null = null;
@@ -91,12 +91,9 @@ export async function serverSupportsJREProvisioning(
   return supports;
 }
 
-export async function fetchJRE(
-  properties: ScannerProperties,
-  platformInfo: PlatformInfo,
-): Promise<string> {
+export async function fetchJRE(properties: ScannerProperties): Promise<string> {
   log(LogLevel.DEBUG, 'Detecting latest version of JRE');
-  const latestJREData = await fetchLatestSupportedJRE(platformInfo);
+  const latestJREData = await fetchLatestSupportedJRE(properties);
   log(LogLevel.INFO, 'Latest Supported JRE: ', latestJREData);
 
   log(LogLevel.DEBUG, 'Looking for Cached JRE');
@@ -126,17 +123,17 @@ export async function fetchJRE(
   }
 }
 
-async function fetchLatestSupportedJRE(platformInfo: PlatformInfo) {
-  log(
-    LogLevel.DEBUG,
-    `Downloading JRE for ${platformInfo.os} ${platformInfo.arch} from ${API_V2_JRE_ENDPOINT}`,
-  );
+async function fetchLatestSupportedJRE(properties: ScannerProperties) {
+  const os = properties[ScannerProperty.SonarScannerOs];
+  const arch = properties[ScannerProperty.SonarScannerArch];
+
+  log(LogLevel.DEBUG, `Downloading JRE for ${os} ${arch} from ${API_V2_JRE_ENDPOINT}`);
 
   const { data } = await fetch({
     url: API_V2_JRE_ENDPOINT,
     params: {
-      os: platformInfo.os,
-      arch: platformInfo.arch,
+      os,
+      arch,
     },
   });
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -20,7 +20,6 @@
 
 import fs from 'fs';
 import { LogLevel, log } from './logging';
-import { PlatformInfo, SupportedOS } from './types';
 
 export function getArch(): NodeJS.Architecture {
   return process.arch;
@@ -53,13 +52,6 @@ function isAlpineLinux(): boolean {
   return !!content && (content.match(/^ID=([^\u001b\r\n]*)/m) || [])[1] === 'alpine';
 }
 
-function getSupportedOS(): SupportedOS {
+export function getSupportedOS(): NodeJS.Platform | 'alpine' {
   return isAlpineLinux() ? 'alpine' : process.platform;
-}
-
-export function getPlatformInfo(): PlatformInfo {
-  return {
-    os: getSupportedOS(),
-    arch: getArch(),
-  };
 }

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -173,7 +173,7 @@ function getSonarFileProperties(projectBaseDir: string): ScannerProperties {
     const sonarPropertiesFile = path.join(projectBaseDir, SONAR_PROJECT_FILENAME);
     const properties: ScannerProperties = {};
     const data = fs.readFileSync(sonarPropertiesFile).toString();
-    const lines = data.split('\n');
+    const lines = data.split(/\r?\n/);
     for (const line of lines) {
       const trimmedLine = line.trim();
       if (trimmedLine.length === 0 || trimmedLine.startsWith('#')) {

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -22,7 +22,6 @@ import { version } from '../package.json';
 import { SCANNER_CLI_DEFAULT_BIN_NAME } from './constants';
 import { fetchJRE, serverSupportsJREProvisioning } from './java';
 import { LogLevel, log, setLogLevel } from './logging';
-import { getPlatformInfo } from './platform';
 import { getProperties } from './properties';
 import { initializeAxios } from './request';
 import { downloadScannerCli, runScannerCli, tryLocalSonarScannerExecutable } from './scanner-cli';
@@ -51,16 +50,18 @@ async function runScan(scanOptions: ScanOptions, cliArgs?: string[]) {
     log(LogLevel.DEBUG, `Overriding the log level to ${properties[ScannerProperty.SonarLogLevel]}`);
   }
 
-  log(LogLevel.DEBUG, 'Properties: ', properties);
+  log(LogLevel.DEBUG, 'Properties:', properties);
+  log(
+    LogLevel.INFO,
+    'Platform:',
+    properties[ScannerProperty.SonarScannerOs],
+    properties[ScannerProperty.SonarScannerArch],
+  );
 
   initializeAxios(properties);
 
   log(LogLevel.INFO, `Server URL: ${properties[ScannerProperty.SonarHostUrl]}`);
   log(LogLevel.INFO, `Version: ${version}`);
-
-  log(LogLevel.DEBUG, 'Finding platform info');
-  const platformInfo = getPlatformInfo();
-  log(LogLevel.INFO, 'Platform: ', platformInfo);
 
   log(LogLevel.DEBUG, 'Check if Server supports JRE Provisioning');
   const supportsJREProvisioning = await serverSupportsJREProvisioning(properties);
@@ -83,7 +84,7 @@ async function runScan(scanOptions: ScanOptions, cliArgs?: string[]) {
 
   // TODO: also check if JRE is explicitly set by properties
   const explicitJREPathOverride = properties[ScannerProperty.SonarScannerJavaExePath];
-  const latestJRE = explicitJREPathOverride ?? (await fetchJRE(properties, platformInfo));
+  const latestJRE = explicitJREPathOverride ?? (await fetchJRE(properties));
   const latestScannerEngine = await fetchScannerEngine(properties);
 
   log(LogLevel.INFO, 'Running the Scanner Engine');

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,13 +19,6 @@
  */
 import { LogLevel } from './logging';
 
-export type SupportedOS = NodeJS.Platform | 'alpine';
-
-export type PlatformInfo = {
-  os: SupportedOS | null;
-  arch: NodeJS.Architecture | null;
-};
-
 export type JreMetaData = {
   filename: string;
   md5: string;
@@ -51,6 +44,8 @@ export enum ScannerProperty {
   SonarExclusions = 'sonar.exclusions',
   SonarHostUrl = 'sonar.host.url',
   SonarUserHome = 'sonar.userHome',
+  SonarScannerOs = 'sonar.scanner.os',
+  SonarScannerArch = 'sonar.scanner.arch',
   SonarOrganization = 'sonar.organization',
   SonarProjectBaseDir = 'sonar.projectBaseDir',
   SonarScannerSonarCloudURL = 'sonar.scanner.sonarcloudUrl',

--- a/test/unit/java.test.ts
+++ b/test/unit/java.test.ts
@@ -89,7 +89,7 @@ describe('java', () => {
     });
 
     it(`should return true for SQ version >= ${SONARQUBE_JRE_PROVISIONING_MIN_VERSION}`, async () => {
-      mock.onGet('/api/server/version').reply(200, '10.5.0');
+      mock.onGet('/api/server/version').reply(200, '10.6.1.3123');
       expect(await serverSupportsJREProvisioning(MOCKED_PROPERTIES)).toBe(true);
     });
 

--- a/test/unit/mocks/FakeProjectMock.ts
+++ b/test/unit/mocks/FakeProjectMock.ts
@@ -58,7 +58,7 @@ export class FakeProjectMock {
       'sonar.scanner.wasEngineCacheHit': 'false',
       'sonar.scanner.wasJreCacheHit': 'false',
       'sonar.scanner.version': SCANNER_CLI_VERSION,
-      'sonar.userHome': '/Users/lucas.paulger/.sonar',
+      'sonar.userHome': expect.stringMatching(/\.sonar$/),
     };
   }
 }

--- a/test/unit/mocks/FakeProjectMock.ts
+++ b/test/unit/mocks/FakeProjectMock.ts
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import path from 'path';
+import sinon from 'sinon';
 import { SCANNER_BOOTSTRAPPER_NAME, SCANNER_CLI_VERSION } from '../../../src/constants';
 
 const baseEnvVariables = process.env;
@@ -37,12 +38,14 @@ export class FakeProjectMock {
     } else {
       this.projectPath = '';
     }
-    process.env = baseEnvVariables;
-    process.cwd = () => this.projectPath;
+    sinon.stub(process, 'platform').value('windows');
+    sinon.stub(process, 'arch').value('aarch64');
+    sinon.stub(process, 'env').value(baseEnvVariables);
+    sinon.stub(process, 'cwd').value(() => this.projectPath);
   }
 
   setEnvironmentVariables(values: { [key: string]: string }) {
-    process.env = values;
+    sinon.stub(process, 'env').value(values);
   }
 
   getStartTime() {
@@ -59,6 +62,8 @@ export class FakeProjectMock {
       'sonar.scanner.wasJreCacheHit': 'false',
       'sonar.scanner.version': SCANNER_CLI_VERSION,
       'sonar.userHome': expect.stringMatching(/\.sonar$/),
+      'sonar.scanner.os': 'windows',
+      'sonar.scanner.arch': 'aarch64',
     };
   }
 }

--- a/test/unit/platform.test.ts
+++ b/test/unit/platform.test.ts
@@ -28,10 +28,8 @@ describe('getPlatformInfo', () => {
     const platformStub = sinon.stub(process, 'platform').value('darwin');
     const archStub = sinon.stub(process, 'arch').value('arm64');
 
-    expect(platform.getPlatformInfo()).toEqual({
-      os: 'darwin',
-      arch: 'arm64',
-    });
+    expect(platform.getSupportedOS()).toEqual('darwin');
+    expect(platform.getArch()).toEqual('arm64');
 
     platformStub.restore();
     archStub.restore();
@@ -41,10 +39,8 @@ describe('getPlatformInfo', () => {
     const platformStub = sinon.stub(process, 'platform').value('win32');
     const archStub = sinon.stub(process, 'arch').value('x64');
 
-    expect(platform.getPlatformInfo()).toEqual({
-      os: 'win32',
-      arch: 'x64',
-    });
+    expect(platform.getSupportedOS()).toEqual('win32');
+    expect(platform.getArch()).toEqual('x64');
 
     platformStub.restore();
     archStub.restore();
@@ -54,10 +50,8 @@ describe('getPlatformInfo', () => {
     const platformStub = sinon.stub(process, 'platform').value('openbsd');
     const archStub = sinon.stub(process, 'arch').value('x64');
 
-    expect(platform.getPlatformInfo()).toEqual({
-      os: 'openbsd',
-      arch: 'x64',
-    });
+    expect(platform.getSupportedOS()).toEqual('openbsd');
+    expect(platform.getArch()).toEqual('x64');
 
     platformStub.restore();
     archStub.restore();
@@ -69,10 +63,8 @@ describe('getPlatformInfo', () => {
     const fsReadStub = sinon.stub(fs, 'readFileSync');
     fsReadStub.withArgs('/etc/os-release').returns('NAME="Alpine Linux"\nID=alpine');
 
-    expect(platform.getPlatformInfo()).toEqual({
-      os: 'alpine',
-      arch: 'x64',
-    });
+    expect(platform.getSupportedOS()).toEqual('alpine');
+    expect(platform.getArch()).toEqual('x64');
 
     platformStub.restore();
     archStub.restore();
@@ -85,10 +77,8 @@ describe('getPlatformInfo', () => {
     const fsReadStub = sinon.stub(fs, 'readFileSync');
     fsReadStub.withArgs('/usr/lib/os-release').returns('NAME="Alpine Linux"\nID=alpine');
 
-    expect(platform.getPlatformInfo()).toEqual({
-      os: 'alpine',
-      arch: 'x64',
-    });
+    expect(platform.getSupportedOS()).toEqual('alpine');
+    expect(platform.getArch()).toEqual('x64');
 
     platformStub.restore();
     archStub.restore();
@@ -98,11 +88,10 @@ describe('getPlatformInfo', () => {
   it('failed to detect alpine', () => {
     const platformStub = sinon.stub(process, 'platform').value('linux');
     const archStub = sinon.stub(process, 'arch').value('x64');
+    const fsReadStub = sinon.stub(fs, 'readFileSync');
 
-    expect(platform.getPlatformInfo()).toEqual({
-      os: 'linux',
-      arch: 'x64',
-    });
+    expect(platform.getSupportedOS()).toEqual('linux');
+    expect(platform.getArch()).toEqual('x64');
 
     expect(log).toHaveBeenCalledWith(
       LogLevel.WARN,
@@ -111,5 +100,6 @@ describe('getPlatformInfo', () => {
 
     platformStub.restore();
     archStub.restore();
+    fsReadStub.restore();
   });
 });

--- a/test/unit/properties.test.ts
+++ b/test/unit/properties.test.ts
@@ -17,6 +17,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
+import sinon from 'sinon';
 import {
   DEFAULT_SONAR_EXCLUSIONS,
   SCANNER_BOOTSTRAPPER_NAME,
@@ -36,6 +37,7 @@ jest.mock('../../package.json', () => ({
 const projectHandler = new FakeProjectMock();
 
 afterEach(() => {
+  sinon.restore();
   projectHandler.reset();
 });
 
@@ -79,6 +81,7 @@ describe('getProperties', () => {
           verbose: true,
           options: {
             'sonar.projectKey': 'use-this-project-key',
+            'sonar.scanner.os': 'some-os',
           },
         },
         projectHandler.getStartTime(),
@@ -94,6 +97,7 @@ describe('getProperties', () => {
         'sonar.projectName': 'Foo',
         'sonar.projectVersion': '1.0-SNAPSHOT',
         'sonar.sources': 'the-sources',
+        'sonar.scanner.os': 'some-os',
       });
     });
 

--- a/test/unit/scan.test.ts
+++ b/test/unit/scan.test.ts
@@ -65,12 +65,10 @@ describe('scan', () => {
 
   it('should output the current platform', async () => {
     jest.spyOn(java, 'serverSupportsJREProvisioning').mockResolvedValue(false);
-    jest.spyOn(platform, 'getPlatformInfo').mockReturnValue({ os: 'alpine', arch: 'arm64' });
+    jest.spyOn(platform, 'getSupportedOS').mockReturnValue('alpine');
+    jest.spyOn(platform, 'getArch').mockReturnValue('arm64');
     await scan({}, []);
-    expect(logging.log).toHaveBeenCalledWith('INFO', 'Platform: ', {
-      os: 'alpine',
-      arch: 'arm64',
-    });
+    expect(logging.log).toHaveBeenCalledWith('INFO', 'Platform:', 'alpine', 'arm64');
   });
 
   describe('when the SQ version does not support JRE provisioning', () => {


### PR DESCRIPTION
- Fix min SQ version that supports JRE provisioning
- Fix hardcoded path to sonar cache folder in tests
- Fix newline parsing when trying to get sonar project files
- Make use of `sonar.scanner.os/arch` when provided by the user