### PR TITLE
Enable `shell` on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "mkdirp": "3.0.1",
         "node-downloader-helper": "2.1.9",
         "progress": "2.0.3",
-        "shell-quote": "1.8.1",
         "slugify": "1.6.6"
       },
       "bin": {
@@ -4574,11 +4573,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/shell-quote": {
-      "version": "1.8.1",
-      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/shell-quote/-/shell-quote-1.8.1.tgz",
-      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA=="
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "mkdirp": "3.0.1",
     "node-downloader-helper": "2.1.9",
     "progress": "2.0.3",
-    "shell-quote": "1.8.1",
     "slugify": "1.6.6"
   },
   "devDependencies": {

--- a/src/config.js
+++ b/src/config.js
@@ -24,6 +24,7 @@ const os = require('os');
 const fs = require('fs');
 const log = require('fancy-log');
 const { HttpsProxyAgent } = require('https-proxy-agent');
+const { isWindows } = require('./utils/platform');
 
 module.exports.getScannerParams = getScannerParams;
 module.exports.extendWithExecParams = extendWithExecParams;
@@ -195,5 +196,6 @@ function extendWithExecParams(env = {}) {
     // (if this value is exceeded then the child process is killed).
     // TODO: make this customizable
     maxBuffer: ONE_MB,
+    shell: isWindows(),
   };
 }

--- a/src/config.js
+++ b/src/config.js
@@ -196,6 +196,6 @@ function extendWithExecParams(env = {}) {
     // (if this value is exceeded then the child process is killed).
     // TODO: make this customizable
     maxBuffer: ONE_MB,
-    shell: isWindows(), //we need to enable sheel on windows due to CVE-2024-27980
+    shell: isWindows(), //we need to enable shell on windows due to CVE-2024-27980
   };
 }

--- a/src/config.js
+++ b/src/config.js
@@ -196,6 +196,6 @@ function extendWithExecParams(env = {}) {
     // (if this value is exceeded then the child process is killed).
     // TODO: make this customizable
     maxBuffer: ONE_MB,
-    shell: isWindows(),
+    shell: isWindows(), //we need to enable sheel on windows due to CVE-2024-27980
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-const quote = require('shell-quote').quote;
 const exec = require('child_process').execFileSync;
 const log = require('fancy-log');
 const { getScannerParams, extendWithExecParams } = require('./config');
@@ -37,7 +36,7 @@ async function scan(params, cliArgs = [], localScanner = false) {
   // prepare the exec options, most notably with the SQ params
   const scannerParams = getScannerParams(process.cwd(), params);
   const execOptions = extendWithExecParams(scannerParams);
-  exec(quote([sqScannerCommand]), fromParam().concat(cliArgs), execOptions);
+  exec(sqScannerCommand, fromParam().concat(cliArgs), execOptions);
   log('Analysis finished.');
 }
 

--- a/src/sonar-scanner-executable.js
+++ b/src/sonar-scanner-executable.js
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-const quote = require('shell-quote').quote;
 const exec = require('child_process').execFileSync;
 const mkdirs = require('mkdirp').sync;
 const { DownloaderHelper } = require('node-downloader-helper');
@@ -121,7 +120,7 @@ async function getSonarScannerExecutable(params = {}) {
 function getLocalSonarScannerExecutable(command = 'sonar-scanner') {
   try {
     log(`Trying to find a local install of the SonarScanner: ${command}`);
-    exec(quote([command]), ['-v']);
+    exec(command, ['-v'], { shell: true });
     // TODO: we should check that it's at least v2.8+
     log('Local install of Sonarscanner found.');
     return command;

--- a/test/unit/config.test.js
+++ b/test/unit/config.test.js
@@ -30,7 +30,7 @@ const {
   SONAR_SCANNER_MIRROR,
 } = require('../../src/config');
 const { buildInstallFolderPath, buildExecutablePath } = require('../../src/utils/paths');
-const { findTargetOS } = require('../../src/utils/platform');
+const { findTargetOS, isWindows } = require('../../src/utils/platform');
 
 function pathForProject(projectFolder) {
   return path.join(__dirname, 'fixtures', projectFolder);
@@ -279,6 +279,7 @@ describe('config', function () {
       assert.deepEqual(extendWithExecParams({ hello: 2 }), {
         maxBuffer: 1024 * 1024,
         stdio: 'inherit',
+        shell: isWindows(),
         env: {
           hello: 2,
           whatsup: 'dog',
@@ -292,6 +293,7 @@ describe('config', function () {
       assert.deepEqual(extendWithExecParams(), {
         env: {},
         maxBuffer: 1024 * 1024,
+        shell: isWindows(),
         stdio: 'inherit',
       });
     });


### PR DESCRIPTION
Fixes #113 

nothing from the env is being passed as arguments in the cmd, so we should be safe. Only cli args will be forwarded