### PR TITLE
SCANNPM-2 Add support for remaining properties

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -48,6 +48,8 @@ export function initializeAxios(properties: ScannerProperties) {
   const token = properties[ScannerProperty.SonarToken];
   const baseURL = properties[ScannerProperty.SonarHostUrl];
   const agents = getHttpAgents(properties);
+  const timeout =
+    Math.floor(parseInt(properties[ScannerProperty.SonarScannerResponseTimeout], 10) || 0) * 1000;
 
   if (!_axiosInstance) {
     _axiosInstance = axios.create({
@@ -55,6 +57,7 @@ export function initializeAxios(properties: ScannerProperties) {
       headers: {
         Authorization: `Bearer ${token}`,
       },
+      timeout,
       ...agents,
     });
   }

--- a/src/scanner-engine.ts
+++ b/src/scanner-engine.ts
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import { spawn } from 'child_process';
+import fs from 'fs';
 import {
   extractArchive,
   getCacheDirectories,
@@ -90,7 +91,7 @@ async function logOutput(message: string) {
   }
 }
 
-export async function runScannerEngine(
+export function runScannerEngine(
   javaBinPath: string,
   scannerEnginePath: string,
   scanOptions: ScanOptions,
@@ -108,6 +109,20 @@ export async function runScannerEngine(
     '-jar',
     scannerEnginePath,
   ];
+
+  // If debugging with dumpToFile, write the properties to a file and exit
+  const dumpToFile = properties[ScannerProperty.SonarScannerInternalDumpToFile];
+  if (dumpToFile) {
+    const data = {
+      propertiesJSON,
+      javaBinPath,
+      scannerEnginePath,
+      args,
+    };
+    log(LogLevel.INFO, 'Dumping data to file and exiting');
+    return fs.promises.writeFile(dumpToFile, JSON.stringify(data, null, 2));
+  }
+
   log(LogLevel.DEBUG, 'Running scanner engine', javaBinPath, ...args);
   const child = spawn(javaBinPath, args);
 

--- a/src/scanner-engine.ts
+++ b/src/scanner-engine.ts
@@ -96,6 +96,8 @@ export async function runScannerEngine(
   scanOptions: ScanOptions,
   properties: ScannerProperties,
 ) {
+  log(LogLevel.INFO, 'Running the Scanner Engine');
+
   // The scanner engine expects a JSON object of properties attached to a key name "scannerProperties"
   const propertiesJSON = JSON.stringify({ scannerProperties: properties });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export enum ScannerProperty {
   SonarScannerProxyPort = 'sonar.scanner.proxyPort',
   SonarScannerProxyUser = 'sonar.scanner.proxyUser',
   SonarScannerProxyPassword = 'sonar.scanner.proxyPassword',
+  SonarScannerResponseTimeout = 'sonar.scanner.responseTimeout',
   SonarScannerSkipJreProvisioning = 'sonar.scanner.skipJreProvisioning',
   SonarScannerInternalDumpToFile = 'sonar.scanner.internal.dumpToFile',
   SonarScannerInternalIsSonarCloud = 'sonar.scanner.internal.isSonarCloud',

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export enum ScannerProperty {
   SonarScannerProxyPort = 'sonar.scanner.proxyPort',
   SonarScannerProxyUser = 'sonar.scanner.proxyUser',
   SonarScannerProxyPassword = 'sonar.scanner.proxyPassword',
+  SonarScannerSkipJreProvisioning = 'sonar.scanner.skipJreProvisioning',
   SonarScannerInternalIsSonarCloud = 'sonar.scanner.internal.isSonarCloud',
   SonarScannerInternalSqVersion = 'sonar.scanner.internal.sqVersion',
   SonarScannerCliVersion = 'sonar.scanner.version',

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,7 @@ export enum ScannerProperty {
   SonarScannerProxyUser = 'sonar.scanner.proxyUser',
   SonarScannerProxyPassword = 'sonar.scanner.proxyPassword',
   SonarScannerSkipJreProvisioning = 'sonar.scanner.skipJreProvisioning',
+  SonarScannerInternalDumpToFile = 'sonar.scanner.internal.dumpToFile',
   SonarScannerInternalIsSonarCloud = 'sonar.scanner.internal.isSonarCloud',
   SonarScannerInternalSqVersion = 'sonar.scanner.internal.sqVersion',
   SonarScannerCliVersion = 'sonar.scanner.version',

--- a/test/unit/request.test.ts
+++ b/test/unit/request.test.ts
@@ -69,6 +69,27 @@ describe('request', () => {
         headers: {
           Authorization: `Bearer testToken`,
         },
+        timeout: 0,
+      });
+    });
+
+    it('should initialize axios with timeout', () => {
+      jest.spyOn(axios, 'create');
+
+      const properties: ScannerProperties = {
+        [ScannerProperty.SonarHostUrl]: 'https://sonarcloud.io',
+        [ScannerProperty.SonarToken]: 'testToken',
+        [ScannerProperty.SonarScannerResponseTimeout]: '23',
+      };
+
+      initializeAxios(properties);
+
+      expect(axios.create).toHaveBeenCalledWith({
+        baseURL: 'https://sonarcloud.io',
+        headers: {
+          Authorization: `Bearer testToken`,
+        },
+        timeout: 23000,
       });
     });
 

--- a/test/unit/scanner-engine.test.ts
+++ b/test/unit/scanner-engine.test.ts
@@ -29,6 +29,7 @@ import { fetchScannerEngine, runScannerEngine } from '../../src/scanner-engine';
 import { ScannerProperties, ScannerProperty } from '../../src/types';
 import { ChildProcessMock } from './mocks/ChildProcessMock';
 import { logWithPrefix } from '../../src/logging';
+import fs from 'fs';
 
 const mock = new MockAdapter(axios);
 
@@ -200,6 +201,23 @@ describe('scanner-engine', () => {
       );
 
       stdoutStub.restore();
+    });
+
+    it('should dump data to file when dumpToFile property is set', async () => {
+      childProcessHandler.setExitCode(1); // Make it so the scanner would fail
+      const writeFile = jest.spyOn(fs.promises, 'writeFile').mockResolvedValue();
+
+      await runScannerEngine(
+        '/some/path/to/java',
+        '/some/path/to/scanner-engine',
+        {},
+        {
+          ...MOCKED_PROPERTIES,
+          [ScannerProperty.SonarScannerInternalDumpToFile]: '/path/to/dump.json',
+        },
+      );
+
+      expect(writeFile).toHaveBeenCalledWith('/path/to/dump.json', expect.any(String));
     });
 
     it.each([['http'], ['https']])(


### PR DESCRIPTION
- Support skipJreProvisioning property to skip JRE provisioning
- Support sonar.scanner.internal.dumpToFile properties
- Support sonar.scanner.responseTimeout properties
  - Axios doesn’t support socketTimeout, so we can simply use responseTimeout in the bootstrapper