### PR TITLE
SCANNPM-2 Use new endpoints & checksum/download logic & Do not use axios instance when fetching absolute URLs

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,9 +23,9 @@ export const SCANNER_BOOTSTRAPPER_NAME = 'ScannerNpm';
 
 export const SONARCLOUD_URL = 'https://sonarcloud.io';
 
-export const SONARCLOUD_URL_REGEX = /^(https?:\/\/)?(www\.)?(sonarcloud\.io)/;
+export const SONARCLOUD_API_BASE_URL = 'https://api.sonarcloud.io';
 
-export const SONARCLOUD_PRODUCTION_URL = 'https://sonarcloud.io';
+export const SONARCLOUD_URL_REGEX = /^(https?:\/\/)?(www\.)?(sonarcloud\.io)/;
 
 export const SONARQUBE_JRE_PROVISIONING_MIN_VERSION = '10.6';
 
@@ -49,10 +49,11 @@ export const SONAR_PROJECT_FILENAME = 'sonar-project.properties';
 export const DEFAULT_SONAR_EXCLUSIONS =
   'node_modules/**,bower_components/**,jspm_packages/**,typings/**,lib-cov/**';
 
-export const API_V2_VERSION_ENDPOINT = '/api/v2/analysis/version';
+export const API_V2_VERSION_ENDPOINT = '/analysis/version';
+export const API_V2_JRE_ENDPOINT = '/analysis/jres';
+export const API_V2_SCANNER_ENGINE_ENDPOINT = '/analysis/engine';
+
 export const API_OLD_VERSION_ENDPOINT = '/api/server/version';
-export const API_V2_JRE_ENDPOINT = '/api/v2/analysis/jres';
-export const API_V2_SCANNER_ENGINE_ENDPOINT = '/api/v2/analysis/engine';
 
 export const SCANNER_CLI_DEFAULT_BIN_NAME = 'sonar-scanner';
 export const SCANNER_CLI_VERSION = '5.0.1.3006';

--- a/src/java.ts
+++ b/src/java.ts
@@ -35,14 +35,19 @@ import {
 } from './file';
 import { LogLevel, log } from './logging';
 import { download, fetch } from './request';
-import { ScannerProperties, ScannerProperty } from './types';
+import {
+  AnalysisJreMetaData,
+  AnalysisJresResponseType,
+  ScannerProperties,
+  ScannerProperty,
+} from './types';
 
-export async function fetchServerVersion(): Promise<SemVer> {
+export async function fetchServerVersion(properties: ScannerProperties): Promise<SemVer> {
   let version: SemVer | null = null;
   try {
     // Try and fetch the new version endpoint first
     log(LogLevel.DEBUG, `Fetching API V2 ${API_V2_VERSION_ENDPOINT}`);
-    const response = await fetch({
+    const response = await fetch<string>({
       url: API_V2_VERSION_ENDPOINT,
     });
     version = semver.coerce(response.data);
@@ -53,8 +58,8 @@ export async function fetchServerVersion(): Promise<SemVer> {
         LogLevel.DEBUG,
         `Unable to fetch API V2 ${API_V2_VERSION_ENDPOINT}: ${error}. Falling back on ${API_OLD_VERSION_ENDPOINT}`,
       );
-      const response = await fetch({
-        url: API_OLD_VERSION_ENDPOINT,
+      const response = await fetch<string>({
+        url: `${properties[ScannerProperty.SonarHostUrl]}${API_OLD_VERSION_ENDPOINT}`,
       });
       version = semver.coerce(response.data);
     } catch (error: unknown) {
@@ -73,9 +78,9 @@ export async function fetchServerVersion(): Promise<SemVer> {
 }
 
 export async function serverSupportsJREProvisioning(
-  parameters: ScannerProperties,
+  properties: ScannerProperties,
 ): Promise<boolean> {
-  if (parameters[ScannerProperty.SonarScannerInternalIsSonarCloud] === 'true') {
+  if (properties[ScannerProperty.SonarScannerInternalIsSonarCloud] === 'true') {
     //TODO: return to true once SC has the new provisioning mechanism in place
     return false;
   }
@@ -83,8 +88,8 @@ export async function serverSupportsJREProvisioning(
   // SonarQube
   log(LogLevel.DEBUG, 'Detecting SonarQube server version');
   const SQServerInfo =
-    semver.coerce(parameters[ScannerProperty.SonarScannerInternalSqVersion]) ??
-    (await fetchServerVersion());
+    semver.coerce(properties[ScannerProperty.SonarScannerInternalSqVersion]) ??
+    (await fetchServerVersion(properties));
   log(LogLevel.INFO, 'SonarQube server version: ', SQServerInfo.version);
 
   const supports = semver.satisfies(SQServerInfo, `>=${SONARQUBE_JRE_PROVISIONING_MIN_VERSION}`);
@@ -94,43 +99,44 @@ export async function serverSupportsJREProvisioning(
 
 export async function fetchJRE(properties: ScannerProperties): Promise<string> {
   log(LogLevel.DEBUG, 'Detecting latest version of JRE');
-  const latestJREData = await fetchLatestSupportedJRE(properties);
-  log(LogLevel.INFO, 'Latest Supported JRE: ', latestJREData);
+  const jreMetaData = await fetchLatestSupportedJRE(properties);
+  log(LogLevel.INFO, 'Latest Supported JRE: ', jreMetaData);
 
   log(LogLevel.DEBUG, 'Looking for Cached JRE');
-  const cachedJRE = await getCacheFileLocation(properties, {
-    md5: latestJREData.md5,
-    filename: latestJREData.filename + UNARCHIVE_SUFFIX,
+  const cachedJrePath = await getCacheFileLocation(properties, {
+    checksum: jreMetaData.sha256,
+    filename: jreMetaData.filename + UNARCHIVE_SUFFIX,
   });
-  if (cachedJRE) {
+  properties[ScannerProperty.SonarScannerWasJreCacheHit] = Boolean(cachedJrePath).toString();
+  if (cachedJrePath) {
     log(LogLevel.INFO, 'Using Cached JRE');
-    properties[ScannerProperty.SonarScannerWasJRECacheHit] = 'true';
-
-    return path.join(cachedJRE, latestJREData.javaPath);
-  } else {
-    const { archivePath, unarchivePath: jreDirPath } = await getCacheDirectories(
-      properties,
-      latestJREData,
-    );
-
-    await download(`${API_V2_JRE_ENDPOINT}/${latestJREData.filename}`, archivePath);
-    log(LogLevel.INFO, `Downloaded JRE to ${archivePath}`);
-
-    await validateChecksum(archivePath, latestJREData.md5);
-
-    await extractArchive(archivePath, jreDirPath);
-
-    return path.join(jreDirPath, latestJREData.javaPath);
+    return path.join(cachedJrePath, jreMetaData.javaPath);
   }
+
+  // JRE not found in cache. Download it.
+  const { archivePath, unarchivePath: jreDirPath } = await getCacheDirectories(properties, {
+    checksum: jreMetaData.sha256,
+    filename: jreMetaData.filename,
+  });
+
+  // If the JRE has a download URL, download it
+  const url = jreMetaData.downloadUrl ?? `${API_V2_JRE_ENDPOINT}/${jreMetaData.id}`;
+
+  await download(url, archivePath);
+  await validateChecksum(archivePath, jreMetaData.sha256);
+  await extractArchive(archivePath, jreDirPath);
+  return path.join(jreDirPath, jreMetaData.javaPath);
 }
 
-async function fetchLatestSupportedJRE(properties: ScannerProperties) {
+async function fetchLatestSupportedJRE(
+  properties: ScannerProperties,
+): Promise<AnalysisJreMetaData> {
   const os = properties[ScannerProperty.SonarScannerOs];
   const arch = properties[ScannerProperty.SonarScannerArch];
 
   log(LogLevel.DEBUG, `Downloading JRE for ${os} ${arch} from ${API_V2_JRE_ENDPOINT}`);
 
-  const { data } = await fetch({
+  const { data } = await fetch<AnalysisJresResponseType>({
     url: API_V2_JRE_ENDPOINT,
     params: {
       os,
@@ -138,6 +144,10 @@ async function fetchLatestSupportedJRE(properties: ScannerProperties) {
     },
   });
 
-  log(LogLevel.DEBUG, 'JRE information: ', data);
-  return data;
+  if (data.length === 0) {
+    throw new Error(`No JREs available for your platform ${os} ${arch}`);
+  }
+
+  log(LogLevel.DEBUG, 'JRE Information', data);
+  return data[0];
 }

--- a/src/request.ts
+++ b/src/request.ts
@@ -30,8 +30,14 @@ import { ScannerProperties, ScannerProperty } from './types';
 
 const finished = promisify(stream.finished);
 
-// The axios instance is private to this module
-let _axiosInstance: AxiosInstance | null = null;
+/**
+ * Axios instances (private to this module).
+ * One for sonar host (with auth), one for external requests
+ */
+let _axiosInstances: {
+  internal: AxiosInstance;
+  external: AxiosInstance;
+} | null = null;
 
 async function extractTruststoreCerts(p12Base64: string, password: string = ''): Promise<string[]> {
   // P12/PFX file -> DER -> ASN.1 -> PKCS12
@@ -95,37 +101,51 @@ export async function getHttpAgents(
   return agents;
 }
 
+export function resetAxios() {
+  _axiosInstances = null;
+}
+
 export async function initializeAxios(properties: ScannerProperties) {
   const token = properties[ScannerProperty.SonarToken];
-  const baseURL = properties[ScannerProperty.SonarHostUrl];
+  const baseURL = properties[ScannerProperty.SonarScannerApiBaseUrl];
   const agents = await getHttpAgents(properties);
   const timeout =
     Math.floor(parseInt(properties[ScannerProperty.SonarScannerResponseTimeout], 10) || 0) * 1000;
 
-  if (!_axiosInstance) {
-    _axiosInstance = axios.create({
-      baseURL,
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-      timeout,
-      ...agents,
-    });
+  if (!_axiosInstances) {
+    _axiosInstances = {
+      internal: axios.create({
+        baseURL,
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        timeout,
+        ...agents,
+      }),
+      external: axios.create({
+        timeout,
+        ...agents,
+      }),
+    };
   }
 }
 
-export function fetch(config: AxiosRequestConfig) {
-  if (!_axiosInstance) {
+export function fetch<T = unknown>(config: AxiosRequestConfig) {
+  if (!_axiosInstances) {
     throw new Error('Axios instance is not initialized');
   }
-
-  return _axiosInstance.request(config);
+  // Use external instance for absolute URLs
+  if (!config.url?.startsWith('/')) {
+    log(LogLevel.DEBUG, `Not using axios instance for ${config.url}`);
+    return _axiosInstances.external.request<T>(config);
+  }
+  return _axiosInstances.internal.request<T>(config);
 }
 
 export async function download(url: string, destPath: string) {
   log(LogLevel.DEBUG, `Downloading ${url} to ${destPath}`);
 
-  const response = await fetch({
+  const response = await fetch<NodeJS.ReadStream>({
     url,
     method: 'GET',
     responseType: 'stream',

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,17 +19,7 @@
  */
 import { LogLevel } from './logging';
 
-export type JreMetaData = {
-  filename: string;
-  md5: string;
-  javaPath: string;
-};
-
-export type CacheFileData = { md5: string; filename: string };
-
-export type JREFullData = JreMetaData & {
-  jrePath: string;
-};
+export type CacheFileData = { checksum: string; filename: string };
 
 export type ScannerLogEntry = {
   level: LogLevel;
@@ -44,13 +34,14 @@ export enum ScannerProperty {
   SonarExclusions = 'sonar.exclusions',
   SonarHostUrl = 'sonar.host.url',
   SonarUserHome = 'sonar.userHome',
+  SonarScannerApiBaseUrl = 'sonar.scanner.apiBaseUrl',
   SonarScannerOs = 'sonar.scanner.os',
   SonarScannerArch = 'sonar.scanner.arch',
   SonarOrganization = 'sonar.organization',
   SonarProjectBaseDir = 'sonar.projectBaseDir',
-  SonarScannerSonarCloudURL = 'sonar.scanner.sonarcloudUrl',
+  SonarScannerSonarCloudUrl = 'sonar.scanner.sonarcloudUrl',
   SonarScannerJavaExePath = 'sonar.scanner.javaExePath',
-  SonarScannerWasJRECacheHit = 'sonar.scanner.wasJRECacheHit',
+  SonarScannerWasJreCacheHit = 'sonar.scanner.wasJreCacheHit',
   SonarScannerWasEngineCacheHit = 'sonar.scanner.wasEngineCacheHit',
   SonarScannerProxyHost = 'sonar.scanner.proxyHost',
   SonarScannerProxyPort = 'sonar.scanner.proxyPort',
@@ -87,4 +78,22 @@ export type ScanOptions = {
 export type CliArgs = {
   debug?: boolean;
   define?: string[];
+};
+
+export type AnalysisJreMetaData = {
+  id: string;
+  filename: string;
+  sha256: string;
+  javaPath: string;
+  os: string;
+  arch: string;
+  downloadUrl?: string;
+};
+
+export type AnalysisJresResponseType = AnalysisJreMetaData[];
+
+export type AnalysisEngineResponseType = {
+  filename: string;
+  sha256: string;
+  downloadUrl?: string;
 };

--- a/test/unit/java.test.ts
+++ b/test/unit/java.test.ts
@@ -25,7 +25,7 @@ import { API_V2_JRE_ENDPOINT, SONARQUBE_JRE_PROVISIONING_MIN_VERSION } from '../
 import * as file from '../../src/file';
 import { fetchJRE, fetchServerVersion, serverSupportsJREProvisioning } from '../../src/java';
 import * as request from '../../src/request';
-import { JreMetaData, ScannerProperties, ScannerProperty } from '../../src/types';
+import { AnalysisJresResponseType, ScannerProperties, ScannerProperty } from '../../src/types';
 
 const mock = new MockAdapter(axios);
 
@@ -46,36 +46,38 @@ beforeEach(() => {
 describe('java', () => {
   describe('version should be detected correctly', () => {
     it('the SonarQube version should be fetched correctly when new endpoint does not exist', async () => {
-      mock.onGet('/api/server/version').reply(200, '3.2.2');
+      mock.onGet('http://sonarqube.com/api/server/version').reply(200, '3.2.2');
 
       mock.onGet('/api/v2/analysis/version').reply(404, 'Not Found');
 
-      const serverSemver = await fetchServerVersion();
+      const serverSemver = await fetchServerVersion(MOCKED_PROPERTIES);
       expect(serverSemver.toString()).toEqual('3.2.2');
       expect(request.fetch).toHaveBeenCalledTimes(2);
     });
 
     it('the SonarQube version should be fetched correctly using the new endpoint', async () => {
-      mock.onGet('/api/server/version').reply(200, '3.2.1.12313');
+      mock.onGet('http://sonarqube.com/api/server/version').reply(200, '3.2.1.12313');
 
-      const serverSemver = await fetchServerVersion();
+      const serverSemver = await fetchServerVersion(MOCKED_PROPERTIES);
       expect(serverSemver.toString()).toEqual('3.2.1');
     });
 
     it('should fail if both endpoints do not work', async () => {
-      mock.onGet('/api/server/version').reply(404, 'Not Found');
+      mock.onGet('http://sonarqube.com/api/server/version').reply(404, 'Not Found');
       mock.onGet('/api/v2/server/version').reply(404, 'Not Found');
 
       expect(async () => {
-        await fetchServerVersion();
+        await fetchServerVersion(MOCKED_PROPERTIES);
       }).rejects.toBeDefined();
     });
 
     it('should fail if version can not be parsed', async () => {
-      mock.onGet('/api/server/version').reply(200, '<!DOCTYPE><HTML><BODY>FORBIDDEN</BODY></HTML>');
+      mock
+        .onGet('http://sonarqube.com/api/server/version')
+        .reply(200, '<!DOCTYPE><HTML><BODY>FORBIDDEN</BODY></HTML>');
 
       expect(async () => {
-        await fetchServerVersion();
+        await fetchServerVersion(MOCKED_PROPERTIES);
       }).rejects.toBeDefined();
     });
   });
@@ -91,26 +93,30 @@ describe('java', () => {
     });
 
     it(`should return true for SQ version >= ${SONARQUBE_JRE_PROVISIONING_MIN_VERSION}`, async () => {
-      mock.onGet('/api/server/version').reply(200, '10.6.1.3123');
+      mock.onGet('http://sonarqube.com/api/server/version').reply(200, '10.6.1.3123');
       expect(await serverSupportsJREProvisioning(MOCKED_PROPERTIES)).toBe(true);
     });
 
     it(`should return false for SQ version < ${SONARQUBE_JRE_PROVISIONING_MIN_VERSION}`, async () => {
       // Define the behavior of the GET request
-      mock.onGet('/api/server/version').reply(200, '9.9.9');
+      mock.onGet('http://sonarqube.com/api/server/version').reply(200, '9.9.9');
       expect(await serverSupportsJREProvisioning(MOCKED_PROPERTIES)).toBe(false);
     });
   });
 
   describe('when JRE provisioning is supported', () => {
-    const serverResponse: JreMetaData = {
-      filename: 'mock-jre.tar.gz',
-      javaPath: 'jre/bin/java',
-      md5: 'd41d8cd98f00b204e9800998ecf8427e',
-    };
+    const serverResponse: AnalysisJresResponseType = [
+      {
+        id: 'some-id',
+        filename: 'mock-jre.tar.gz',
+        javaPath: 'jre/bin/java',
+        sha256: 'd41d8cd98f00b204e9800998ecf8427e',
+        arch: 'arm64',
+        os: 'linux',
+      },
+    ];
     beforeEach(() => {
       jest.spyOn(file, 'getCacheFileLocation').mockResolvedValue('mocked/path/to/file');
-
       jest.spyOn(file, 'extractArchive').mockResolvedValue(undefined);
 
       mock
@@ -123,7 +129,7 @@ describe('java', () => {
         .reply(200, serverResponse);
 
       mock
-        .onGet(`${API_V2_JRE_ENDPOINT}/${serverResponse.filename}`)
+        .onGet(`${API_V2_JRE_ENDPOINT}/${serverResponse[0].id}`)
         .reply(200, fs.createReadStream(path.resolve(__dirname, '../unit/mocks/mock-jre.tar.gz')));
     });
 
@@ -134,7 +140,7 @@ describe('java', () => {
         expect(request.fetch).toHaveBeenCalledTimes(1);
         expect(request.download).not.toHaveBeenCalled();
 
-        // check for the cache
+        // Check for the cache
         expect(file.getCacheFileLocation).toHaveBeenCalledTimes(1);
 
         expect(file.extractArchive).not.toHaveBeenCalled();
@@ -167,13 +173,29 @@ describe('java', () => {
         expect(file.getCacheFileLocation).toHaveBeenCalledTimes(1);
 
         expect(request.download).toHaveBeenCalledWith(
-          `${API_V2_JRE_ENDPOINT}/${serverResponse.filename}`,
+          `${API_V2_JRE_ENDPOINT}/${serverResponse[0].id}`,
           mockCacheDirectories.archivePath,
         );
 
         expect(file.validateChecksum).toHaveBeenCalledTimes(1);
 
         expect(file.extractArchive).toHaveBeenCalledTimes(1);
+      });
+
+      it('should fail if no JRE matches', async () => {
+        mock
+          .onGet(API_V2_JRE_ENDPOINT, {
+            params: {
+              os: MOCKED_PROPERTIES[ScannerProperty.SonarScannerOs],
+              arch: MOCKED_PROPERTIES[ScannerProperty.SonarScannerArch],
+            },
+          })
+          .reply(200, []);
+
+        // Check that it rejects with a specific error
+        expect(fetchJRE({ ...MOCKED_PROPERTIES })).rejects.toThrowError(
+          'No JREs available for your platform linux arm64',
+        );
       });
     });
   });

--- a/test/unit/properties.test.ts
+++ b/test/unit/properties.test.ts
@@ -21,6 +21,7 @@ import sinon from 'sinon';
 import {
   DEFAULT_SONAR_EXCLUSIONS,
   SCANNER_BOOTSTRAPPER_NAME,
+  SONARCLOUD_API_BASE_URL,
   SONARCLOUD_URL,
 } from '../../src/constants';
 import { LogLevel, log } from '../../src/logging';
@@ -50,7 +51,8 @@ describe('getProperties', () => {
 
     expect(properties).toEqual({
       ...projectHandler.getExpectedProperties(),
-      'sonar.host.url': 'https://sonarcloud.io',
+      'sonar.host.url': SONARCLOUD_URL,
+      'sonar.scanner.apiBaseUrl': SONARCLOUD_API_BASE_URL,
       'sonar.scanner.internal.isSonarCloud': 'true',
       'sonar.projectDescription': 'No description.',
       'sonar.sources': '.',
@@ -67,7 +69,7 @@ describe('getProperties', () => {
         {
           options: {
             'sonar.projectKey': 'use-this-project-key',
-            'sonar.scanner.sonarcloudUrl': 'https://dev.sc-dev.io',
+            'sonar.scanner.apiBaseUrl': 'https://dev.sc-dev.io',
           },
         },
         projectHandler.getStartTime(),
@@ -75,8 +77,8 @@ describe('getProperties', () => {
 
       expect(properties).toEqual({
         ...projectHandler.getExpectedProperties(),
-        'sonar.host.url': 'https://dev.sc-dev.io',
-        'sonar.scanner.sonarcloudUrl': 'https://dev.sc-dev.io',
+        'sonar.host.url': SONARCLOUD_URL,
+        'sonar.scanner.apiBaseUrl': 'https://dev.sc-dev.io',
         'sonar.scanner.internal.isSonarCloud': 'true',
         'sonar.projectKey': 'use-this-project-key',
         'sonar.projectDescription': 'No description.',
@@ -105,6 +107,7 @@ describe('getProperties', () => {
       expect(properties).toEqual({
         ...projectHandler.getExpectedProperties(),
         'sonar.host.url': 'http://localhost/sonarqube',
+        'sonar.scanner.apiBaseUrl': 'http://localhost/sonarqube/api/v2',
         'sonar.scanner.internal.isSonarCloud': 'false',
         'sonar.token': 'dummy-token',
         'sonar.verbose': 'true',
@@ -147,6 +150,7 @@ describe('getProperties', () => {
       expect(properties).toEqual({
         ...projectHandler.getExpectedProperties(),
         'sonar.host.url': 'http://localhost/sonarqube',
+        'sonar.scanner.apiBaseUrl': 'http://localhost/sonarqube/api/v2',
         'sonar.scanner.internal.isSonarCloud': 'false',
         'sonar.javascript.lcov.reportPaths': 'coverage/lcov.info',
         'sonar.projectKey': 'fake-basic-project',
@@ -174,6 +178,7 @@ describe('getProperties', () => {
       expect(properties).toEqual({
         ...projectHandler.getExpectedProperties(),
         'sonar.host.url': 'http://localhost/sonarqube',
+        'sonar.scanner.apiBaseUrl': 'http://localhost/sonarqube/api/v2',
         'sonar.scanner.internal.isSonarCloud': 'false',
         'sonar.projectKey': 'fake-project',
         'sonar.projectName': 'fake-project',
@@ -202,6 +207,7 @@ describe('getProperties', () => {
       expect(properties).toEqual({
         ...projectHandler.getExpectedProperties(),
         'sonar.host.url': 'http://localhost/sonarqube',
+        'sonar.scanner.apiBaseUrl': 'http://localhost/sonarqube/api/v2',
         'sonar.scanner.internal.isSonarCloud': 'false',
         'sonar.projectDescription': 'No description.',
         'sonar.sources': '.',
@@ -223,6 +229,7 @@ describe('getProperties', () => {
       expect(properties).toEqual({
         ...projectHandler.getExpectedProperties(),
         'sonar.host.url': 'http://localhost/sonarqube',
+        'sonar.scanner.apiBaseUrl': 'http://localhost/sonarqube/api/v2',
         'sonar.scanner.internal.isSonarCloud': 'false',
         'sonar.projectDescription': 'No description.',
         'sonar.sources': '.',
@@ -247,6 +254,7 @@ describe('getProperties', () => {
       expect(properties).toEqual({
         ...projectHandler.getExpectedProperties(),
         'sonar.host.url': 'http://localhost/sonarqube',
+        'sonar.scanner.apiBaseUrl': 'http://localhost/sonarqube/api/v2',
         'sonar.scanner.internal.isSonarCloud': 'false',
         'sonar.javascript.lcov.reportPaths': 'jest-coverage/lcov.info',
         'sonar.projectKey': 'fake-basic-project',
@@ -272,6 +280,7 @@ describe('getProperties', () => {
       expect(properties).toEqual({
         ...projectHandler.getExpectedProperties(),
         'sonar.host.url': 'http://localhost/sonarqube',
+        'sonar.scanner.apiBaseUrl': 'http://localhost/sonarqube/api/v2',
         'sonar.scanner.internal.isSonarCloud': 'false',
         'sonar.javascript.lcov.reportPaths': 'nyc-coverage/lcov.info',
         'sonar.projectKey': 'fake-basic-project',
@@ -312,6 +321,7 @@ describe('getProperties', () => {
       expect(properties).toEqual({
         ...projectHandler.getExpectedProperties(),
         'sonar.host.url': 'http://localhost/sonarqube',
+        'sonar.scanner.apiBaseUrl': 'http://localhost/sonarqube/api/v2',
         'sonar.scanner.internal.isSonarCloud': 'false',
         'sonar.projectKey': 'foo',
         'sonar.projectName': 'Foo',
@@ -335,7 +345,8 @@ describe('getProperties', () => {
 
       expect(properties).toEqual({
         ...projectHandler.getExpectedProperties(),
-        'sonar.host.url': 'https://sonarqube.com/',
+        'sonar.host.url': 'https://sonarqube.com',
+        'sonar.scanner.apiBaseUrl': 'https://sonarqube.com/api/v2',
         'sonar.scanner.internal.isSonarCloud': 'false',
         'sonar.projectKey': 'foo',
         'sonar.projectName': 'Foo',
@@ -358,6 +369,7 @@ describe('getProperties', () => {
       expect(properties).toEqual({
         ...projectHandler.getExpectedProperties(),
         'sonar.host.url': SONARCLOUD_URL,
+        'sonar.scanner.apiBaseUrl': SONARCLOUD_API_BASE_URL,
         'sonar.scanner.internal.isSonarCloud': 'true',
         'sonar.projectKey': 'foo',
         'sonar.projectName': 'Foo',
@@ -382,6 +394,7 @@ describe('getProperties', () => {
       expect(properties).toEqual({
         ...projectHandler.getExpectedProperties(),
         'sonar.host.url': `${protocol}://localhost/sonarqube`,
+        'sonar.scanner.apiBaseUrl': `${protocol}://localhost/sonarqube/api/v2`,
         'sonar.scanner.internal.isSonarCloud': 'false',
         'sonar.projectKey': 'foo',
         'sonar.projectName': 'Foo',
@@ -407,6 +420,7 @@ describe('getProperties', () => {
       expect(properties).toEqual({
         ...projectHandler.getExpectedProperties(),
         'sonar.host.url': SONARCLOUD_URL,
+        'sonar.scanner.apiBaseUrl': SONARCLOUD_API_BASE_URL,
         'sonar.scanner.internal.isSonarCloud': 'true',
         'sonar.projectKey': 'foo',
         'sonar.projectName': 'Foo',
@@ -427,6 +441,7 @@ describe('getProperties', () => {
       expect(properties).toEqual({
         ...projectHandler.getExpectedProperties(),
         'sonar.host.url': SONARCLOUD_URL,
+        'sonar.scanner.apiBaseUrl': SONARCLOUD_API_BASE_URL,
         'sonar.scanner.internal.isSonarCloud': 'true',
         'sonar.projectKey': 'foo',
         'sonar.projectName': 'Foo',
@@ -452,6 +467,7 @@ describe('getProperties', () => {
       expect(properties).toEqual({
         ...projectHandler.getExpectedProperties(),
         'sonar.host.url': SONARCLOUD_URL,
+        'sonar.scanner.apiBaseUrl': SONARCLOUD_API_BASE_URL,
         'sonar.scanner.internal.isSonarCloud': 'true',
         'sonar.projectKey': 'foo',
         'sonar.projectName': 'Foo',
@@ -482,6 +498,7 @@ describe('getProperties', () => {
       expect(properties).toEqual({
         ...projectHandler.getExpectedProperties(),
         'sonar.host.url': 'http://localhost/sonarqube',
+        'sonar.scanner.apiBaseUrl': 'http://localhost/sonarqube/api/v2',
         'sonar.scanner.internal.isSonarCloud': 'false',
         'sonar.projectKey': 'foo',
         'sonar.projectName': 'Foo',
@@ -522,6 +539,7 @@ describe('getProperties', () => {
       expect(properties).toEqual({
         ...projectHandler.getExpectedProperties(),
         'sonar.host.url': 'http://localhost/sonarqube',
+        'sonar.scanner.apiBaseUrl': 'http://localhost/sonarqube/api/v2',
         'sonar.scanner.internal.isSonarCloud': 'false',
         'sonar.projectKey': 'used',
         'sonar.projectName': 'Foo',
@@ -568,6 +586,7 @@ describe('getProperties', () => {
       expect(properties).toEqual({
         ...projectHandler.getExpectedProperties(),
         'sonar.host.url': 'http://localhost/sonarqube',
+        'sonar.scanner.apiBaseUrl': 'http://localhost/sonarqube/api/v2',
         'sonar.scanner.internal.isSonarCloud': 'false',
         'sonar.projectKey': 'foo',
         'sonar.projectName': 'Foo',
@@ -595,12 +614,13 @@ describe('getProperties', () => {
             },
           },
           projectHandler.getStartTime(),
-          ['-Dsonar.scanner.proxyHost=use-this-proxy.io'],
+          { define: ['sonar.scanner.proxyHost=use-this-proxy.io'] },
         );
 
         expect(properties).toEqual({
           ...projectHandler.getExpectedProperties(),
           'sonar.host.url': `${protocol}://localhost/sonarqube`,
+          'sonar.scanner.apiBaseUrl': `${protocol}://localhost/sonarqube/api/v2`,
           'sonar.scanner.internal.isSonarCloud': 'false',
           'sonar.projectKey': 'foo',
           'sonar.projectName': 'Foo',
@@ -614,10 +634,11 @@ describe('getProperties', () => {
 });
 
 describe('addHostProperties', () => {
-  it('should detect SonarCloud', () => {
+  it('should detect SonarCloud by default', () => {
     const expected = {
       [ScannerProperty.SonarScannerInternalIsSonarCloud]: 'true',
-      [ScannerProperty.SonarHostUrl]: 'https://sonarcloud.io',
+      [ScannerProperty.SonarHostUrl]: SONARCLOUD_URL,
+      [ScannerProperty.SonarScannerApiBaseUrl]: SONARCLOUD_API_BASE_URL,
     };
 
     // SonarCloud used by default
@@ -626,7 +647,7 @@ describe('addHostProperties', () => {
     // Backward-compatible use-case
     expect(
       getHostProperties({
-        [ScannerProperty.SonarHostUrl]: 'https://sonarcloud.io',
+        [ScannerProperty.SonarHostUrl]: SONARCLOUD_URL,
       }),
     ).toEqual(expected);
 
@@ -647,13 +668,15 @@ describe('addHostProperties', () => {
 
   it('should detect SonarCloud with custom URL', () => {
     const endpoint = getHostProperties({
-      [ScannerProperty.SonarHostUrl]: 'https://sonarcloud.io/',
-      [ScannerProperty.SonarScannerSonarCloudURL]: 'http://that-is-a-sonarcloud-custom-url.com',
+      [ScannerProperty.SonarHostUrl]: 'http://that-is-a-sonarcloud-custom-url.com',
+      [ScannerProperty.SonarScannerSonarCloudUrl]: 'http://that-is-a-sonarcloud-custom-url.com',
+      [ScannerProperty.SonarScannerApiBaseUrl]: 'http://api.that-is-a-sonarcloud-custom-url.com',
     });
 
     expect(endpoint).toEqual({
       [ScannerProperty.SonarScannerInternalIsSonarCloud]: 'true',
       [ScannerProperty.SonarHostUrl]: 'http://that-is-a-sonarcloud-custom-url.com',
+      [ScannerProperty.SonarScannerApiBaseUrl]: 'http://api.that-is-a-sonarcloud-custom-url.com',
     });
   });
 
@@ -665,18 +688,20 @@ describe('addHostProperties', () => {
     expect(endpoint).toEqual({
       [ScannerProperty.SonarScannerInternalIsSonarCloud]: 'false',
       [ScannerProperty.SonarHostUrl]: 'https://next.sonarqube.com',
+      [ScannerProperty.SonarScannerApiBaseUrl]: 'https://next.sonarqube.com/api/v2',
     });
   });
 
   it('should ignore SonarCloud custom URL if sonar host URL does not match sonarcloud', () => {
     const endpoint = getHostProperties({
       [ScannerProperty.SonarHostUrl]: 'https://next.sonarqube.com',
-      [ScannerProperty.SonarScannerSonarCloudURL]: 'http://that-is-a-sonarcloud-custom-url.com',
+      [ScannerProperty.SonarScannerSonarCloudUrl]: 'http://that-is-a-sonarcloud-custom-url.com',
     });
 
     expect(endpoint).toEqual({
       [ScannerProperty.SonarScannerInternalIsSonarCloud]: 'false',
       [ScannerProperty.SonarHostUrl]: 'https://next.sonarqube.com',
+      [ScannerProperty.SonarScannerApiBaseUrl]: 'https://next.sonarqube.com/api/v2',
     });
   });
 });

--- a/test/unit/scanner-cli.test.ts
+++ b/test/unit/scanner-cli.test.ts
@@ -17,8 +17,8 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import * as fsExtra from 'fs-extra';
 import { spawn } from 'child_process';
+import * as fsExtra from 'fs-extra';
 import path from 'path';
 import sinon from 'sinon';
 import {
@@ -275,7 +275,7 @@ describe('scanner-cli', () => {
 
   describe('normalizePlatformName', function () {
     it('detect Windows', function () {
-      const stub = sinon.stub(process, 'platform').value('windows10');
+      const stub = sinon.stub(process, 'platform').value('win32');
 
       expect(normalizePlatformName()).toEqual('windows');
       stub.restore();

--- a/test/unit/scanner-engine.test.ts
+++ b/test/unit/scanner-engine.test.ts
@@ -21,15 +21,16 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { ChildProcess, spawn } from 'child_process';
+import fs from 'fs';
 import sinon from 'sinon';
 import { Readable } from 'stream';
+import { API_V2_SCANNER_ENGINE_ENDPOINT } from '../../src/constants';
 import * as file from '../../src/file';
+import { logWithPrefix } from '../../src/logging';
 import * as request from '../../src/request';
 import { fetchScannerEngine, runScannerEngine } from '../../src/scanner-engine';
-import { ScannerProperties, ScannerProperty } from '../../src/types';
+import { AnalysisEngineResponseType, ScannerProperties, ScannerProperty } from '../../src/types';
 import { ChildProcessMock } from './mocks/ChildProcessMock';
-import { logWithPrefix } from '../../src/logging';
-import fs from 'fs';
 
 const mock = new MockAdapter(axios);
 
@@ -39,8 +40,8 @@ const MOCKED_PROPERTIES: ScannerProperties = {
 };
 
 const MOCK_CACHE_DIRECTORIES = {
-  archivePath: 'mocked/path/to/sonar/cache/md5_test/scanner-engine-1.2.3.zip',
-  unarchivePath: 'mocked/path/to/sonar/cache/md5_test/scanner-engine-1.2.3.zip_extracted',
+  archivePath: 'mocked/path/to/sonar/cache/sha_test/scanner-engine-1.2.3.zip',
+  unarchivePath: 'mocked/path/to/sonar/cache/sha_test/scanner-engine-1.2.3.zip_extracted',
 };
 jest.mock('../../src/constants', () => ({
   ...jest.requireActual('../../src/constants'),
@@ -60,17 +61,28 @@ beforeEach(() => {
 describe('scanner-engine', () => {
   beforeEach(async () => {
     request.initializeAxios(MOCKED_PROPERTIES);
-    mock.onGet('/batch/index').reply(200, 'scanner-engine-1.2.3.zip|md5_test');
-    mock.onGet('/batch/file?name=scanner-engine-1.2.3.zip').reply(() => {
-      const readable = new Readable({
-        read() {
-          this.push('md5_test');
-          this.push(null); // Indicates end of stream
-        },
-      });
+    mock.onGet(API_V2_SCANNER_ENGINE_ENDPOINT).reply(200, {
+      filename: 'scanner-engine-1.2.3.zip',
+      sha256: 'sha_test',
+    } as AnalysisEngineResponseType);
+    mock
+      .onGet(
+        API_V2_SCANNER_ENGINE_ENDPOINT,
+        undefined,
+        expect.objectContaining({
+          Accept: expect.stringMatching(/application\/octet-stream/),
+        }),
+      )
+      .reply(() => {
+        const readable = new Readable({
+          read() {
+            this.push('sha_test');
+            this.push(null); // Indicates end of stream
+          },
+        });
 
-      return [200, readable];
-    });
+        return [200, readable];
+      });
 
     jest.spyOn(file, 'getCacheFileLocation').mockResolvedValue(null);
     jest.spyOn(file, 'extractArchive').mockResolvedValue();
@@ -84,7 +96,7 @@ describe('scanner-engine', () => {
       await fetchScannerEngine(MOCKED_PROPERTIES);
 
       expect(file.getCacheFileLocation).toHaveBeenCalledWith(MOCKED_PROPERTIES, {
-        md5: 'md5_test',
+        checksum: 'sha_test',
         filename: 'scanner-engine-1.2.3.zip',
       });
     });
@@ -98,7 +110,7 @@ describe('scanner-engine', () => {
         const scannerEngine = await fetchScannerEngine(MOCKED_PROPERTIES);
 
         expect(file.getCacheFileLocation).toHaveBeenCalledWith(MOCKED_PROPERTIES, {
-          md5: 'md5_test',
+          checksum: 'sha_test',
           filename: 'scanner-engine-1.2.3.zip',
         });
         expect(request.download).not.toHaveBeenCalled();
@@ -113,14 +125,14 @@ describe('scanner-engine', () => {
         const scannerEngine = await fetchScannerEngine(MOCKED_PROPERTIES);
 
         expect(file.getCacheFileLocation).toHaveBeenCalledWith(MOCKED_PROPERTIES, {
-          md5: 'md5_test',
+          checksum: 'sha_test',
           filename: 'scanner-engine-1.2.3.zip',
         });
         expect(request.download).toHaveBeenCalledTimes(1);
         expect(file.extractArchive).toHaveBeenCalledTimes(1);
 
         expect(scannerEngine).toEqual(
-          'mocked/path/to/sonar/cache/md5_test/scanner-engine-1.2.3.zip_extracted',
+          'mocked/path/to/sonar/cache/sha_test/scanner-engine-1.2.3.zip_extracted',
         );
       });
     });

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -26,7 +26,7 @@ const sinon = require('sinon');
 describe('utils', function () {
   describe('findTargetOS()', function () {
     it('detect Windows', function () {
-      const stub = sinon.stub(process, 'platform').value('windows10');
+      const stub = sinon.stub(process, 'platform').value('win32');
 
       assert.equal(findTargetOS(), 'windows');
       stub.restore();


### PR DESCRIPTION
[ticket](https://sonarsource.atlassian.net/browse/SCANNPM-25)