### PR TITLE
SCANNPM-2 Change wasJreCacheHit from bool to enum and mark it disabled when skipping JRE provisioning explicitly

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -62,3 +62,5 @@ export const SCANNER_CLI_VERSION = '5.0.1.3006';
 export const SCANNER_CLI_MIRROR =
   'https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/';
 export const SCANNER_CLI_INSTALL_PATH = 'native-sonar-scanner';
+
+export const WINDOWS_WHERE_EXE_PATH = 'C:\\Windows\\System32\\where.exe';

--- a/src/java.ts
+++ b/src/java.ts
@@ -38,6 +38,7 @@ import { download, fetch } from './request';
 import {
   AnalysisJreMetaData,
   AnalysisJresResponseType,
+  CacheStatus,
   ScannerProperties,
   ScannerProperty,
 } from './types';
@@ -113,7 +114,9 @@ export async function fetchJRE(properties: ScannerProperties): Promise<string> {
     checksum: jreMetaData.sha256,
     filename: jreMetaData.filename + UNARCHIVE_SUFFIX,
   });
-  properties[ScannerProperty.SonarScannerWasJreCacheHit] = Boolean(cachedJrePath).toString();
+  properties[ScannerProperty.SonarScannerWasJreCacheHit] = cachedJrePath
+    ? CacheStatus.Hit
+    : CacheStatus.Miss;
   if (cachedJrePath) {
     log(LogLevel.INFO, 'Using Cached JRE');
     return path.join(cachedJrePath, jreMetaData.javaPath);

--- a/src/process.ts
+++ b/src/process.ts
@@ -1,0 +1,51 @@
+/*
+ * sonar-scanner-npm
+ * Copyright (C) 2022-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { exec } from 'child_process';
+import util from 'util';
+import { WINDOWS_WHERE_EXE_PATH } from './constants';
+import { log, LogLevel } from './logging';
+import { isWindows } from './platform';
+
+const execAsync = util.promisify(exec);
+
+/**
+ * Verify that a given executable is accessible from the PATH.
+ * We use where.exe on Windows to check for the existence of the command to avoid
+ * search path vulnerabilities. Otherwise, Windows would search the current directory
+ * for the executable.
+ */
+export async function locateExecutableFromPath(executable: string): Promise<string | null> {
+  try {
+    log(LogLevel.INFO, `Trying to find ${executable}`);
+    const child = await execAsync(
+      `${isWindows() ? WINDOWS_WHERE_EXE_PATH : 'which'} ${executable}`,
+    );
+    const stdout = child.stdout?.trim();
+    if (stdout.length) {
+      return stdout;
+    }
+    log(LogLevel.INFO, 'Local install of SonarScanner CLI found.');
+    return null;
+  } catch (error) {
+    log(LogLevel.INFO, `Local install of SonarScanner CLI (${executable}) not found`);
+    return null;
+  }
+}

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -34,9 +34,9 @@ import {
   SONAR_DIR_DEFAULT,
   SONAR_PROJECT_FILENAME,
 } from './constants';
-import { log, LogLevel } from './logging';
+import { LogLevel, log } from './logging';
 import { getArch, getSupportedOS } from './platform';
-import { CliArgs, ScannerProperties, ScannerProperty, ScanOptions } from './types';
+import { CacheStatus, CliArgs, ScanOptions, ScannerProperties, ScannerProperty } from './types';
 
 function getDefaultProperties(): ScannerProperties {
   return {
@@ -307,8 +307,9 @@ function getBootstrapperProperties(startTimestampMs: number): ScannerProperties 
     'sonar.scanner.app': SCANNER_BOOTSTRAPPER_NAME,
     'sonar.scanner.appVersion': version,
     'sonar.scanner.bootstrapStartTime': startTimestampMs.toString(),
-    // Bootstrap cache hit/miss is set later after the bootstrapper has run and before scanner engine is started
-    'sonar.scanner.wasJreCacheHit': 'false',
+    // These cache statuses are set during the bootstrapping process.
+    // We already set them here to prevent them from being overridden.
+    'sonar.scanner.wasJreCacheHit': CacheStatus.Disabled,
     'sonar.scanner.wasEngineCacheHit': 'false',
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,3 +98,9 @@ export type AnalysisEngineResponseType = {
   sha256: string;
   downloadUrl?: string;
 };
+
+export enum CacheStatus {
+  Hit = 'hit',
+  Miss = 'miss',
+  Disabled = 'disabled',
+}

--- a/test/unit/mocks/FakeProjectMock.ts
+++ b/test/unit/mocks/FakeProjectMock.ts
@@ -20,6 +20,7 @@
 import path from 'path';
 import sinon from 'sinon';
 import { SCANNER_BOOTSTRAPPER_NAME } from '../../../src/constants';
+import { CacheStatus } from '../../../src/types';
 
 const baseEnvVariables = process.env;
 
@@ -59,7 +60,7 @@ export class FakeProjectMock {
       'sonar.scanner.app': SCANNER_BOOTSTRAPPER_NAME,
       'sonar.scanner.appVersion': '1.2.3',
       'sonar.scanner.wasEngineCacheHit': 'false',
-      'sonar.scanner.wasJreCacheHit': 'false',
+      'sonar.scanner.wasJreCacheHit': CacheStatus.Disabled,
       'sonar.userHome': expect.stringMatching(/\.sonar$/),
       'sonar.scanner.os': 'windows',
       'sonar.scanner.arch': 'aarch64',

--- a/test/unit/process.test.ts
+++ b/test/unit/process.test.ts
@@ -1,0 +1,73 @@
+/*
+ * sonar-scanner-npm
+ * Copyright (C) 2022-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import sinon from 'sinon';
+import { SCANNER_CLI_DEFAULT_BIN_NAME, WINDOWS_WHERE_EXE_PATH } from '../../src/constants';
+import { locateExecutableFromPath } from '../../src/process';
+import { ChildProcessMock } from './mocks/ChildProcessMock';
+
+jest.mock('fs-extra');
+jest.mock('child_process');
+jest.mock('../../src/request');
+jest.mock('../../src/file');
+jest.mock('../../src/logging');
+
+const childProcessHandler = new ChildProcessMock();
+
+beforeEach(() => {
+  childProcessHandler.reset();
+});
+
+describe('process', () => {
+  describe('locateExecutableFromPath', () => {
+    it('should use windows where.exe when on windows', async () => {
+      // mock windows with stub
+      const stub = sinon.stub(process, 'platform').value('win32');
+
+      childProcessHandler.setOutput('/bin/path/to/stuff\n', '');
+
+      expect(await locateExecutableFromPath(SCANNER_CLI_DEFAULT_BIN_NAME)).toBe(
+        '/bin/path/to/stuff',
+      );
+      expect(childProcessHandler.getCommandHistory()).toContain(
+        `${WINDOWS_WHERE_EXE_PATH} ${SCANNER_CLI_DEFAULT_BIN_NAME}`,
+      );
+
+      stub.restore();
+    });
+
+    it('should detect locally installed command', async () => {
+      childProcessHandler.setOutput('some output\n', '');
+
+      expect(await locateExecutableFromPath(SCANNER_CLI_DEFAULT_BIN_NAME)).toBe('some output');
+    });
+
+    it('should not detect locally installed command (when exit code is 1)', async () => {
+      childProcessHandler.setExitCode(1);
+
+      expect(await locateExecutableFromPath(SCANNER_CLI_DEFAULT_BIN_NAME)).toBe(null);
+    });
+
+    it('should not detect locally installed command (when empty stdout)', async () => {
+      childProcessHandler.setOutput('', '');
+
+      expect(await locateExecutableFromPath(SCANNER_CLI_DEFAULT_BIN_NAME)).toBe(null);
+    });
+  });
+});

--- a/test/unit/properties.test.ts
+++ b/test/unit/properties.test.ts
@@ -26,7 +26,7 @@ import {
 } from '../../src/constants';
 import { LogLevel, log } from '../../src/logging';
 import { getHostProperties, getProperties } from '../../src/properties';
-import { ScannerProperty } from '../../src/types';
+import { CacheStatus, ScannerProperty } from '../../src/types';
 import { FakeProjectMock } from './mocks/FakeProjectMock';
 
 jest.mock('../../src/logging');
@@ -615,7 +615,7 @@ describe('getProperties', () => {
           'sonar.scanner.app': 'ignored',
           'sonar.scanner.appVersion': 'ignored',
           'sonar.scanner.bootstrapStartTime': '0000',
-          'sonar.scanner.wasJreCacheHit': 'true',
+          'sonar.scanner.wasJreCacheHit': CacheStatus.Hit,
           'sonar.scanner.wasEngineCacheHit': 'true',
         }),
       });
@@ -627,7 +627,7 @@ describe('getProperties', () => {
             'sonar.scanner.app': 'ignored',
             'sonar.scanner.appVersion': 'ignored',
             'sonar.scanner.bootstrapStartTime': '0000',
-            'sonar.scanner.wasJreCacheHit': 'true',
+            'sonar.scanner.wasJreCacheHit': CacheStatus.Hit,
             'sonar.scanner.wasEngineCacheHit': 'true',
           },
         },


### PR DESCRIPTION
[ticket](https://sonarsource.atlassian.net/browse/SCANNPM-31)