### PR TITLE
SCANNPM-35 Change default values and logic for inferring package.json and sonar-project.properties

### DIFF
--- a/test/unit/fixtures/fake_project_with_package_and_sonar_properties/package.json
+++ b/test/unit/fixtures/fake_project_with_package_and_sonar_properties/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "that-is-the-project-key",
+  "version": "1.0.0",
+  "engines": {
+    "node": ">= 0.10"
+  }
+}

--- a/test/unit/fixtures/fake_project_with_package_and_sonar_properties/sonar-project.properties
+++ b/test/unit/fixtures/fake_project_with_package_and_sonar_properties/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar.sources=the-sources

--- a/test/unit/mocks/FakeProjectMock.ts
+++ b/test/unit/mocks/FakeProjectMock.ts
@@ -19,7 +19,7 @@
  */
 import path from 'path';
 import sinon from 'sinon';
-import { SCANNER_BOOTSTRAPPER_NAME } from '../../../src/constants';
+import { DEFAULT_SONAR_EXCLUSIONS, SCANNER_BOOTSTRAPPER_NAME } from '../../../src/constants';
 import { CacheStatus } from '../../../src/types';
 
 const baseEnvVariables = process.env;
@@ -55,6 +55,7 @@ export class FakeProjectMock {
 
   getExpectedProperties() {
     return {
+      'sonar.exclusions': DEFAULT_SONAR_EXCLUSIONS,
       'sonar.projectBaseDir': this.projectPath,
       'sonar.scanner.bootstrapStartTime': this.startTimeMs.toString(),
       'sonar.scanner.app': SCANNER_BOOTSTRAPPER_NAME,

--- a/test/unit/properties.test.ts
+++ b/test/unit/properties.test.ts
@@ -54,9 +54,6 @@ describe('getProperties', () => {
       'sonar.host.url': SONARCLOUD_URL,
       'sonar.scanner.apiBaseUrl': SONARCLOUD_API_BASE_URL,
       'sonar.scanner.internal.isSonarCloud': 'true',
-      'sonar.projectDescription': 'No description.',
-      'sonar.sources': '.',
-      'sonar.exclusions': DEFAULT_SONAR_EXCLUSIONS,
     });
   });
 
@@ -81,9 +78,6 @@ describe('getProperties', () => {
         'sonar.scanner.apiBaseUrl': 'https://dev.sc-dev.io',
         'sonar.scanner.internal.isSonarCloud': 'true',
         'sonar.projectKey': 'use-this-project-key',
-        'sonar.projectDescription': 'No description.',
-        'sonar.sources': '.',
-        'sonar.exclusions': DEFAULT_SONAR_EXCLUSIONS,
       });
     });
 
@@ -155,9 +149,7 @@ describe('getProperties', () => {
         'sonar.javascript.lcov.reportPaths': 'coverage/lcov.info',
         'sonar.projectKey': 'fake-basic-project',
         'sonar.projectName': 'fake-basic-project',
-        'sonar.projectDescription': 'No description.',
         'sonar.projectVersion': '1.0.0',
-        'sonar.sources': '.',
         'sonar.exclusions': DEFAULT_SONAR_EXCLUSIONS + ',coverage/**',
         'sonar.scanner.app': SCANNER_BOOTSTRAPPER_NAME,
         'sonar.scanner.appVersion': '1.2.3',
@@ -187,9 +179,7 @@ describe('getProperties', () => {
         'sonar.links.homepage': 'https://github.com/fake/project',
         'sonar.links.issue': 'https://github.com/fake/project/issues',
         'sonar.links.scm': 'git+https://github.com/fake/project.git',
-        'sonar.sources': '.',
         'sonar.testExecutionReportPaths': 'xunit.xml',
-        'sonar.exclusions': DEFAULT_SONAR_EXCLUSIONS,
       });
     });
 
@@ -209,9 +199,6 @@ describe('getProperties', () => {
         'sonar.host.url': 'http://localhost/sonarqube',
         'sonar.scanner.apiBaseUrl': 'http://localhost/sonarqube/api/v2',
         'sonar.scanner.internal.isSonarCloud': 'false',
-        'sonar.projectDescription': 'No description.',
-        'sonar.sources': '.',
-        'sonar.exclusions': DEFAULT_SONAR_EXCLUSIONS,
       });
     });
 
@@ -231,9 +218,6 @@ describe('getProperties', () => {
         'sonar.host.url': 'http://localhost/sonarqube',
         'sonar.scanner.apiBaseUrl': 'http://localhost/sonarqube/api/v2',
         'sonar.scanner.internal.isSonarCloud': 'false',
-        'sonar.projectDescription': 'No description.',
-        'sonar.sources': '.',
-        'sonar.exclusions': DEFAULT_SONAR_EXCLUSIONS,
         'sonar.projectKey': 'myfake-basic-project',
         'sonar.projectName': '@my/fake-basic-project',
         'sonar.projectVersion': '1.0.0',
@@ -259,9 +243,7 @@ describe('getProperties', () => {
         'sonar.javascript.lcov.reportPaths': 'jest-coverage/lcov.info',
         'sonar.projectKey': 'fake-basic-project',
         'sonar.projectName': 'fake-basic-project',
-        'sonar.projectDescription': 'No description.',
         'sonar.projectVersion': '1.0.0',
-        'sonar.sources': '.',
         'sonar.exclusions': DEFAULT_SONAR_EXCLUSIONS + ',jest-coverage/**',
       });
     });
@@ -285,9 +267,7 @@ describe('getProperties', () => {
         'sonar.javascript.lcov.reportPaths': 'nyc-coverage/lcov.info',
         'sonar.projectKey': 'fake-basic-project',
         'sonar.projectName': 'fake-basic-project',
-        'sonar.projectDescription': 'No description.',
         'sonar.projectVersion': '1.0.0',
-        'sonar.sources': '.',
         'sonar.exclusions': DEFAULT_SONAR_EXCLUSIONS + ',nyc-coverage/**',
       });
     });
@@ -635,6 +615,29 @@ describe('getProperties', () => {
         'sonar.userHome': '/tmp/used',
         'sonar.organization': 'used',
         'sonar.scanner.someVar': 'used',
+      });
+    });
+
+    it('should correctly merge package.json and sonar-project.properties', () => {
+      projectHandler.reset('fake_project_with_package_and_sonar_properties');
+      projectHandler.setEnvironmentVariables({});
+
+      const properties = getProperties(
+        {
+          serverUrl: 'http://localhost/sonarqube',
+        },
+        projectHandler.getStartTime(),
+      );
+
+      expect(properties).toEqual({
+        ...projectHandler.getExpectedProperties(),
+        'sonar.host.url': 'http://localhost/sonarqube',
+        'sonar.scanner.apiBaseUrl': 'http://localhost/sonarqube/api/v2',
+        'sonar.scanner.internal.isSonarCloud': 'false',
+        'sonar.projectKey': 'that-is-the-project-key',
+        'sonar.projectName': 'that-is-the-project-key',
+        'sonar.projectVersion': '1.0.0',
+        'sonar.sources': 'the-sources',
       });
     });
 


### PR DESCRIPTION
Kind of a follow-up of [this discussion](https://docs.google.com/document/d/1lmQzAHxsDTrBf2PyFa1aBJXvETX-ATznBHYPbZb115w/edit?disco=AAABNsX5ARQ). The priority we have is correct ( `sonar-project.properties` superseeds `package.json`) but the logic we inherited from the existing codebase can this be improvied/simplified. 

See [ticket](https://sonarsource.atlassian.net/browse/SCANNPM-35).

Making the change in the future version, targeting `feature/MMF-3712`, it's also a breaking change.