### PR TITLE
SCANNPM-8 Reintroduce default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The following example shows how to run an analysis on a JavaScript
 project, and pushing the results to a SonarQube instance:
 
 ```javascript
-const scanner = require('sonarqube-scanner');
+const scanner = require('sonarqube-scanner').default;
 
 scanner(
   {
@@ -47,7 +47,12 @@ scanner(
       'sonar.tests': 'test',
     },
   },
-  () => process.exit(),
+  error => {
+    if (error) {
+      console.error(error);
+    }
+    process.exit();
+  },
 );
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,3 +28,15 @@ export function customScanner(scanOptions: ScanOptions) {
     localScannerCli: true,
   });
 }
+
+function scanWithCallback(scanOptions: ScanOptions, callback: (error?: unknown) => void) {
+  return scan(scanOptions)
+    .then(() => {
+      callback();
+    })
+    .catch(error => {
+      callback(error);
+    });
+}
+
+export default scanWithCallback;


### PR DESCRIPTION
Reintroduces the default export (callback-based) because we mention it in the README, so it's likely widely used all around.