### PR TITLE
NO-JIRA Publish v4.0.1 & Fix release pipeline to include build folder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,10 @@ jobs:
         with:
           node-version: 18
       - run: mv .github/workflows/.npmrc .npmrc
+      - name: Build npm package
+        run: |
+          npm install
+          npm run build
       - name: Publish npm package
         env:
           NPM_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).npm_token }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sonarqube-scanner",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sonarqube-scanner",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "adm-zip": "0.5.12",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sonarqube-scanner",
   "description": "SonarQube/SonarCloud Scanner for the JavaScript world",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "homepage": "https://github.com/SonarSource/sonar-scanner-npm",
   "author": {
     "name": "Fabrice Bellingard",


### PR DESCRIPTION
The release pipeline wasn't updated to build the package before releasing, meaning `v4.0.0` does not contain the `build` folder, which makes it impossible for users to use the `v4` at all. 