### PR TITLE
Raise issue about not returning non-zero codes after analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is the documentation for v4. If you are using v3, refer to [the v3 document
 
 ## Installation
 
-_Prerequisite: Node v18+ (for v4 and above)_
+_Prerequisite: Node v18+ (for v4 and above)_ - doesn't return non-zero code comparing to v3
 
 _Prerequisite: Node v16+ (for v3, otherwise use sonarqube-scanner v2.9.1)_
 


### PR DESCRIPTION
Hello,

this is actually a try to bring attention to a major issue (I think this is a bug) in 4.0.0/4.0.1.

Since I can't create an issue at this repository anymore, I've decided to describe it here.

See reported case https://community.sonarsource.com/t/sonarqube-scanner-4-0-0-doesnt-return-non-zero-exit-code-in-case-of-quality-gate-failure/118755

TL;DR: v3 returns non-zero code when Quality Gate fails. With `-Dsonar.qualitygate.wait="true"` this allows us to fail the build on Jenkins.

But v4 of this package **always returns 0 exit code**, making it impossible to fail the build on our side.

I didn't find breaking change in the diff between 3.5.0 and 4.0.0, but from my tests:

- 3.5.0 - works correctly, returns non-zero exit code in case of Quality Gate issues
- 4.0.0 - exit code is awlays `0` (bug)
- 4.0.1 -  exit code is awlays `0` (bug)

----

And please note that while this package has [4.1.0 release](https://github.com/SonarSource/sonar-scanner-npm/releases/tag/4.1.0), `npm`'s latest version is 4.0.1 - so it seems like it was forgotten to publish a new version.
