### PR TITLE
SCANNPM-40 Handle deprecated 'sonar.login' correctly

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -74,4 +74,5 @@ export const SCANNER_DEPRECATED_PROPERTIES: ScannerProperty[][] = [
   [ScannerProperty.HttpProxyPort, ScannerProperty.SonarScannerProxyPort],
   [ScannerProperty.HttpProxyUser, ScannerProperty.SonarScannerProxyUser],
   [ScannerProperty.HttpProxyPassword, ScannerProperty.SonarScannerProxyPassword],
+  [ScannerProperty.SonarLogin, ScannerProperty.SonarToken],
 ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,7 @@ export enum ScannerProperty {
   HttpProxyPort = 'http.proxyPort',
   HttpProxyUser = 'http.proxyUser',
   HttpProxyPassword = 'http.proxyPassword',
+  SonarLogin = 'sonar.login',
 }
 
 export type ScannerProperties = {

--- a/test/unit/properties.test.ts
+++ b/test/unit/properties.test.ts
@@ -497,6 +497,7 @@ describe('getProperties', () => {
           options: {
             'sonar.scanner.responseTimeout': '111',
             'http.proxyHost': 'my-proxy.io',
+            'sonar.login': 'my-login',
           },
         },
         projectHandler.getStartTime(),
@@ -507,6 +508,8 @@ describe('getProperties', () => {
         'sonar.ws.timeout': '111',
         'sonar.scanner.proxyHost': 'my-proxy.io', // Should replace the deprecated property with the new one
         'http.proxyHost': 'my-proxy.io',
+        'sonar.login': 'my-login', // Should not replace the deprecated property because its new version is not present
+        'sonar.token': 'my-login',
       });
       expect(log).toHaveBeenCalledWith(
         LogLevel.WARN,


### PR DESCRIPTION
Context:
https://community.sonarsource.com/t/unable-to-run-js-local-analysis-on-10-6/118997/9
https://sonarsource.atlassian.net/browse/SCANNPM-40

**Old Experience**
```
lucas.paulger@MAC0343 sonar-scanner-npm % sonar-scanner \
  -Dsonar.sources=. \
  -Dsonar.login=sqa_### \
  -Dsonar.host.url=http://localhost:9000 \  -Dsonar.verbose=true \
-Dsonar.qualitygate.wait="true"
[INFO]  Bootstrapper: Retrieving info from "package.json" file
[DEBUG] Bootstrapper: Setting the log level to DEBUG due to verbose mode
[DEBUG] Bootstrapper: Properties: {
  'sonar.scanner.os': 'darwin',
  'sonar.scanner.arch': 'arm64',
  ...
  'sonar.sources': '.',
  'sonar.login': 'sqa_###',
  'sonar.host.url': 'http://localhost:9000',
  'sonar.verbose': 'true',
  'sonar.scanner.internal.isSonarCloud': 'false',
  'sonar.scanner.apiBaseUrl': 'http://localhost:9000/api/v2',
  'sonar.scanner.app': 'ScannerNpm',
  'sonar.scanner.appVersion': '4.1.0',
  'sonar.scanner.bootstrapStartTime': '1721389203774',
  'sonar.scanner.wasJreCacheHit': 'disabled',
  'sonar.scanner.wasEngineCacheHit': 'false',
  ...
}
[INFO]  Bootstrapper: Platform: darwin arm64
[DEBUG] Bootstrapper: Detecting proxy: No proxy detected
[INFO]  Bootstrapper: Server URL: http://localhost:9000
[INFO]  Bootstrapper: Version: 4.1.0
[DEBUG] Bootstrapper: Check if Server supports JRE provisioning
[DEBUG] Bootstrapper: Detecting SonarQube server version
[DEBUG] Bootstrapper: Fetching API V2 /analysis/version
[DEBUG] Bootstrapper: Unable to fetch API V2 /analysis/version: AxiosError: Request failed with status code 401. Falling back on /api/server/version
[DEBUG] Bootstrapper: Not using axios instance for http://localhost:9000/api/server/version
[INFO]  Bootstrapper: SonarQube server version: 10.7.0
[DEBUG] Bootstrapper: SonarQube Server v10.7.0 supports JRE provisioning: true
[INFO]  Bootstrapper: JRE provisioning is supported
[DEBUG] Bootstrapper: Detecting latest version of JRE
[DEBUG] Bootstrapper: Downloading JRE information for darwin arm64 from /analysis/jres
[ERROR] Bootstrapper: An error occurred: AxiosError: Request failed with status code 401
```

**New experience**

```
lucas.paulger@MAC0343 sonar-scanner-npm % sonar-scanner \                                                     
  -Dsonar.sources=. \
  -Dsonar.login=sqa_### \
  -Dsonar.host.url=http://localhost:9000 \  -Dsonar.verbose=true \
-Dsonar.qualitygate.wait="true"

[INFO]  Bootstrapper: Retrieving info from "package.json" file
[WARN]  Bootstrapper: Property "sonar.login" is deprecated and will be removed in a future version. Please use "sonar.token" instead.
[DEBUG] Bootstrapper: Setting the log level to DEBUG due to verbose mode
[DEBUG] Bootstrapper: Properties: {
  'sonar.scanner.os': 'darwin',
  'sonar.scanner.arch': 'arm64',
  ...
  'sonar.sources': '.',
  'sonar.login': 'sqa_###',
  'sonar.host.url': 'http://localhost:9000',
  'sonar.verbose': 'true',
  'sonar.scanner.internal.isSonarCloud': 'false',
  'sonar.scanner.apiBaseUrl': 'http://localhost:9000/api/v2',
  'sonar.scanner.app': 'ScannerNpm',
  'sonar.scanner.appVersion': '4.1.0',
  'sonar.scanner.bootstrapStartTime': '1721390322326',
  'sonar.scanner.wasJreCacheHit': 'disabled',
  'sonar.scanner.wasEngineCacheHit': 'false',
  ...
  'sonar.token': 'sqa_###'
}
[INFO]  Bootstrapper: Platform: darwin arm64
[DEBUG] Bootstrapper: Detecting proxy: No proxy detected
[INFO]  Bootstrapper: Server URL: http://localhost:9000
[INFO]  Bootstrapper: Version: 4.1.0
[DEBUG] Bootstrapper: Check if Server supports JRE provisioning
[DEBUG] Bootstrapper: Detecting SonarQube server version
[DEBUG] Bootstrapper: Fetching API V2 /analysis/version
[INFO]  Bootstrapper: SonarQube server version: 10.7.0
[DEBUG] Bootstrapper: SonarQube Server v10.7.0 supports JRE provisioning: true
[INFO]  Bootstrapper: JRE provisioning is supported
[DEBUG] Bootstrapper: Detecting latest version of JRE
[DEBUG] Bootstrapper: Downloading JRE information for darwin arm64 from /analysis/jres
[DEBUG] Bootstrapper: Latest Supported JRE:  {
  id: '54f81f6e-212c-4cb5-a9cf-7c146a593351',
  filename: 'OpenJDK17U-jre_aarch64_mac_hotspot_17.0.11_9.tar.gz',
  sha256: '003d3e0a65a2f0633b8bfed42be133724b490acb323c174c708d3a446d5fc660',
  javaPath: 'jdk-17.0.11+9-jre/Contents/Home/bin/java',
  os: 'mac',
  arch: 'aarch64'
}
[DEBUG] Bootstrapper: Looking for Cached JRE
...
```