### PR TITLE
SCANNPM-41 Allow package.json not to contain a name entry

### DIFF
--- a/src/properties.ts
+++ b/src/properties.ts
@@ -19,10 +19,10 @@
  */
 import fsExtra from 'fs-extra';
 import path from 'path';
+import { getProperties as getPropertiesFile } from 'properties-file';
 import { getProxyForUrl } from 'proxy-from-env';
 import slugify from 'slugify';
 import { version } from '../package.json';
-import { getProperties as getPropertiesFile } from 'properties-file';
 import {
   DEFAULT_SONAR_EXCLUSIONS,
   ENV_TO_PROPERTY_NAME,
@@ -135,11 +135,15 @@ function dependenceExists(pkg: PackageJson, pkgName: string): boolean {
 
 function populatePackageParams(params: { [key: string]: string | {} }, pkg: PackageJson) {
   const invalidCharacterRegex = /[?$*+~.()'"!:@/]/g;
-  params['sonar.projectKey'] = slugify(pkg.name, {
-    remove: invalidCharacterRegex,
-  });
-  params['sonar.projectName'] = pkg.name;
-  params['sonar.projectVersion'] = pkg.version;
+  if (pkg.name) {
+    params['sonar.projectKey'] = slugify(pkg.name, {
+      remove: invalidCharacterRegex,
+    });
+    params['sonar.projectName'] = pkg.name;
+  }
+  if (pkg.version) {
+    params['sonar.projectVersion'] = pkg.version;
+  }
   if (pkg.description) {
     params['sonar.projectDescription'] = pkg.description;
   }

--- a/test/unit/fixtures/fake_project_with_basic_package_file/package.json
+++ b/test/unit/fixtures/fake_project_with_basic_package_file/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "fake-basic-project",
   "version": "1.0.0",
   "engines": {
     "node": ">= 0.10"

--- a/test/unit/properties.test.ts
+++ b/test/unit/properties.test.ts
@@ -170,8 +170,6 @@ describe('getProperties', () => {
         'sonar.scanner.apiBaseUrl': 'http://localhost/sonarqube/api/v2',
         'sonar.scanner.internal.isSonarCloud': 'false',
         'sonar.javascript.lcov.reportPaths': 'coverage/lcov.info',
-        'sonar.projectKey': 'fake-basic-project',
-        'sonar.projectName': 'fake-basic-project',
         'sonar.projectVersion': '1.0.0',
         'sonar.exclusions': DEFAULT_SONAR_EXCLUSIONS + ',coverage/**',
         'sonar.scanner.app': SCANNER_BOOTSTRAPPER_NAME,


### PR DESCRIPTION
[ticket](https://sonarsource.atlassian.net/browse/SCANNPM-41)

Before this fix, running the NPM scanner with a package.json which did not contain a `name` entry would systematically crash the analysis. According to the user who reported this on community, it was introduced by V4. 