### PR TITLE
NO-JIRA Fix release pipeline and promote jfrog artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,17 +33,18 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-      - name: Create local repository directory
+
+      - name: Create local directory
         id: local_repo
         run: echo "dir=$(mktemp -d repo.XXXXXXXX)" >> $GITHUB_OUTPUT
+
       - name: Get the version
         id: get_version
         run: |
           IFS=. read -r major minor patch build <<< "$RELEASE_TAG"
           echo "build=${build}" >> $GITHUB_OUTPUT
-          echo "patch=${patch}" >> $GITHUB_OUTPUT
-          echo "minor=${minor}" >> $GITHUB_OUTPUT
-          echo "major=${major}" >> $GITHUB_OUTPUT
+          echo "version=${major}.${minor}.${patch}" >> $GITHUB_OUTPUT
+
       - name: Download Artifacts
         uses: SonarSource/gh-action_release/download-build@master
         with:
@@ -52,6 +53,7 @@ jobs:
           remote-repo: sonarsource-npm-public-builds
           flat-download: true
           download-checksums: false
+
       - name: Promote npm package
         env:
           REPOX_URL: ${{ fromJSON(steps.secrets.outputs.vault).repox_url }}
@@ -61,10 +63,21 @@ jobs:
           jfrog config add repox --artifactory-url $REPOX_URL --access-token $PROMOTE_ACCESS_TOKEN
           jfrog config use repox
           jfrog rt bpr --status released ${{ github.event.repository.name }} ${{ steps.get_version.outputs.build }} sonarsource-npm-public-releases
-      - name: Publish npm package to npmjs
+
+      - name: Extract .tgz package
         working-directory: ${{ steps.local_repo.outputs.dir }}
+        run: |
+          file=$(find . -name "*.tgz" -printf "%f")
+          mkdir package
+          tar -xzf "$file" -C package --strip-components=1
+
+      - name: Update package version
+        working-directory: ${{ steps.local_repo.outputs.dir }}/package
+        run: npm version --no-git-tag-version ${{ steps.get_version.outputs.version }}
+
+      - name: Publish npm package to npmjs
+        working-directory: ${{ steps.local_repo.outputs.dir }}/package
         env:
           NPM_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).npm_token }}
         run: |
-          file=$(find -name "*.tgz" -printf "%f")
-          npm publish "$file"
+          npm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,34 +22,36 @@ jobs:
         uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets:
-            development/artifactory/token/SonarSource-sonar-scanner-npm-qa-deployer access_token  | qa_deployer_access_token;
             development/artifactory/token/SonarSource-sonar-scanner-npm-promoter access_token  | promoter_access_token;
             development/kv/data/npmjs sonartech_npm_token  | npm_token;
-            development/kv/data/repox url  | repox_url;
+            development/kv/data/repox artifactory_url  | repox_url;
       - name: Setup JFrog for deploy
         uses: SonarSource/jfrog-setup-wrapper@907e87c3d2081a98d2ab8cb03284ee6711f1ee83 # tag=3.2.3
         with:
-          jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).qa_deployer_access_token }}
+          jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).promoter_access_token }}
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-      - run: mv .github/workflows/.npmrc .npmrc
-      - name: Build npm package
-        env:
-          NPM_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).npm_token }}
+      - name: Create local repository directory
+        id: local_repo
+        run: echo "dir=$(mktemp -d repo.XXXXXXXX)" >> $GITHUB_OUTPUT
+      - name: Get the version
+        id: get_version
         run: |
-          npm install
-          npm run build
-      - name: Publish npm package
-        env:
-          NPM_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).npm_token }}
-        run: |
-          jfrog rt npm-config --repo-resolve npm --repo-deploy $ARTIFACTORY_DEPLOY_REPO
-          jfrog rt npm-ci
-          npm publish
-          jfrog rt npm-publish --build-name=$PACKAGE --build-number=${{ github.event.release.tag_name }}
-          jfrog rt build-publish $PACKAGE ${{ github.event.release.tag_name }}
+          IFS=. read -r major minor patch build <<< "$RELEASE_TAG"
+          echo "build=${build}" >> $GITHUB_OUTPUT
+          echo "patch=${patch}" >> $GITHUB_OUTPUT
+          echo "minor=${minor}" >> $GITHUB_OUTPUT
+          echo "major=${major}" >> $GITHUB_OUTPUT
+      - name: Download Artifacts
+        uses: SonarSource/gh-action_release/download-build@master
+        with:
+          build-number: ${{ steps.get_version.outputs.build }}
+          local-repo-dir: ${{ steps.local_repo.outputs.dir }}
+          remote-repo: sonarsource-npm-public-builds
+          flat-download: true
+          download-checksums: false
       - name: Promote npm package
         env:
           REPOX_URL: ${{ fromJSON(steps.secrets.outputs.vault).repox_url }}
@@ -58,5 +60,11 @@ jobs:
         run: |
           jfrog config add repox --artifactory-url $REPOX_URL --access-token $PROMOTE_ACCESS_TOKEN
           jfrog config use repox
-          jfrog rt bpr --status it-passed $PACKAGE $RELEASE_TAG sonarsource-npm-public-builds 
-          jfrog rt bpr --status released $PACKAGE $RELEASE_TAG sonarsource-npm-public-releases
+          jfrog rt bpr --status released ${{ github.event.repository.name }} ${{ steps.get_version.outputs.build }} sonarsource-npm-public-releases
+      - name: Publish npm package to npmjs
+        working-directory: ${{ steps.local_repo.outputs.dir }}
+        env:
+          NPM_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).npm_token }}
+        run: |
+          file=$(find -name "*.tgz" -printf "%f")
+          npm publish "$file"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "license": "eslint --ext js,ts src test tools scripts .",
     "license-fix": "eslint --fix --ext js,ts src test tools scripts .",
     "precommit": "pretty-quick --staged",
-    "prepare": "husky install .husky"
+    "prepare": "husky install .husky || true"
   },
   "prettier": {
     "printWidth": 100,


### PR DESCRIPTION
Fixes are in collaboration w/
https://sonarsource.atlassian.net/browse/BUILD-5492

The core changes are:

1. create a local directory to checkout the jfrog artifacts into
2. populates specific version information to be used in next steps
3. publishes to npm what was checked out into `steps.local_repo.outputs.dir` (see the dry-run example for what will be uploaded -> https://github.com/SonarSource/sonar-scanner-npm/actions/runs/10057370878/job/27798167415#step:9:3)

