### PR TITLE
direct pass SONAR_SCANNER_OPTS to java-process environment

### DIFF
--- a/src/scanner-cli.ts
+++ b/src/scanner-cli.ts
@@ -128,6 +128,7 @@ export async function runScannerCli(
       env: {
         ...Object.fromEntries(filteredEnv),
         SONARQUBE_SCANNER_PARAMS: JSON.stringify(properties),
+        SONAR_SCANNER_OPTS: process.env.SONAR_SCANNER_OPTS,
       },
       shell: isWindows(),
     },


### PR DESCRIPTION
I have to configure a selfsigned certificate using sonar-scanner-npm

I tried to follow https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/various-setups/manage-tls-certificates/ but it did not work for me.
It seems that node part is not passing the SONAR_SCANNER_OPTS for the java-process.

Problem seems to be that SONAR_SCANNER_OPTS starts with SONAR_SCANNER_ witch will be filtered out by ENV_VAR_PREFIX

scanner-cli.ts line 117 to 122:
```javascript
  // We filter out env properties that are passed to the scanner
  // otherwise, they would supersede the properties passed to the scanner through SONARQUBE_SCANNER_PARAMS
  const filteredEnvKeys = ENV_TO_PROPERTY_NAME.map(env => env[0]);
  const filteredEnv = Object.entries(process.env)
    .filter(([key]) => !filteredEnvKeys.includes(key))
    .filter(([key]) => !key.startsWith(ENV_VAR_PREFIX));
```

Maybe there is a better solution for this, then I would welcome suggestions