### PR TITLE
Update dependencies to use ranges

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "4.2.1",
       "license": "LGPL-3.0-only",
       "dependencies": {
-        "adm-zip": "0.5.12",
-        "axios": "1.6.8",
-        "commander": "12.0.0",
-        "fs-extra": "11.2.0",
-        "hpagent": "1.2.0",
-        "jest-sonar-reporter": "2.0.0",
+        "adm-zip": "^0.5.12",
+        "axios": "^1.6.8",
+        "commander": "^12.0.0",
+        "fs-extra": "^11.2.0",
+        "hpagent": "^1.2.0",
+        "jest-sonar-reporter": "^2.0.0",
         "node-forge": "^1.3.1",
-        "properties-file": "3.5.4",
+        "properties-file": "^3.5.4",
         "proxy-from-env": "^1.1.0",
-        "semver": "7.6.0",
-        "slugify": "1.6.6",
-        "tar-stream": "3.1.7"
+        "semver": "^7.6.0",
+        "slugify": "^1.6.6",
+        "tar-stream": "^3.1.7"
       },
       "bin": {
         "sonar-scanner": "bin/sonar-scanner"
@@ -1706,8 +1706,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.6.8",
-      "license": "MIT",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -1859,11 +1860,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2589,9 +2591,10 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -3059,8 +3062,9 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -4912,8 +4916,9 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -24,18 +24,18 @@
     "node": ">= 18"
   },
   "dependencies": {
-    "adm-zip": "0.5.12",
-    "axios": "1.6.8",
-    "commander": "12.0.0",
-    "fs-extra": "11.2.0",
-    "hpagent": "1.2.0",
-    "jest-sonar-reporter": "2.0.0",
+    "adm-zip": "^0.5.12",
+    "axios": "^1.6.8",
+    "commander": "^12.0.0",
+    "fs-extra": "^11.2.0",
+    "hpagent": "^1.2.0",
+    "jest-sonar-reporter": "^2.0.0",
     "node-forge": "^1.3.1",
-    "properties-file": "3.5.4",
+    "properties-file": "^3.5.4",
     "proxy-from-env": "^1.1.0",
-    "semver": "7.6.0",
-    "slugify": "1.6.6",
-    "tar-stream": "3.1.7"
+    "semver": "^7.6.0",
+    "slugify": "^1.6.6",
+    "tar-stream": "^3.1.7"
   },
   "devDependencies": {
     "@types/adm-zip": "0.5.5",


### PR DESCRIPTION
Allow patch and minor upgrades on dependencies to allow consumers to upgrade transitive deps in case of CVEs and other issues.