### PR TITLE
SCANNPM-56 Remove deprecated CIRRUS_AWS_SUBNET

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -1,4 +1,4 @@
-load("github.com/SonarSource/cirrus-modules@v2", "load_features")
+load("github.com/SonarSource/cirrus-modules@v3", "load_features")
 
 def main(ctx):
     return load_features(ctx)

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,7 +35,6 @@ npmrc_script_definition: &NPMRC_SCRIPT_DEFINITION
     - cp .cirrus/npmrc $CIRRUS_WORKING_DIR/test/integration/.npmrc
 
 ec2_instance: &INSTANCE_DEFINITION
-  experimental: true # see https://github.com/cirruslabs/cirrus-ci-docs/issues/1051
   region: eu-central-1
   type: t3.medium
   image: base-windows-jdk17-v*

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,7 +25,6 @@ container_definition: &CONTAINER_DEFINITION
   builder_role: cirrus-builder
   builder_image: docker-builder-v*
   builder_instance_type: t2.small
-  builder_subnet_id: ${CIRRUS_AWS_SUBNET}
   region: eu-central-1
   namespace: default
 
@@ -38,7 +37,6 @@ npmrc_script_definition: &NPMRC_SCRIPT_DEFINITION
 ec2_instance: &INSTANCE_DEFINITION
   experimental: true # see https://github.com/cirruslabs/cirrus-ci-docs/issues/1051
   region: eu-central-1
-  subnet_id: ${CIRRUS_AWS_SUBNET}
   type: t3.medium
   image: base-windows-jdk17-v*
   platform: windows


### PR DESCRIPTION
[SCANNPM-56](https://sonarsource.atlassian.net/browse/SCANNPM-56)

Inspired by https://github.com/SonarSource/SonarJS/commit/8d7834cbecefc004f54541bec871ce1fde34d3ad

See also BUILD-6666

[SCANNPM-56]: https://sonarsource.atlassian.net/browse/SCANNPM-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ