### PR TITLE
SCANNPM-55 Fix Node 23+ compatibility by avoiding sending directories to fs.createWriteStream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sonarqube-scanner",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sonarqube-scanner",
-      "version": "4.2.5",
+      "version": "4.2.6",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "adm-zip": "0.5.12",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sonarqube-scanner",
   "description": "SonarQube/SonarCloud Scanner for the JavaScript world",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "homepage": "https://github.com/SonarSource/sonar-scanner-npm",
   "author": {
     "name": "Fabrice Bellingard",


### PR DESCRIPTION
[ticket](https://sonarsource.atlassian.net/browse/SCANNPM-55)

Reproduce bug:
```bash
# be in the repo on master branch
nvm install 23
nvm use 23
npm run build
rm -fr ~/.sonar/cache
SONAR_TOKEN=xxxxx ./bin/sonar-scanner
```

error

```text
node:internal/fs/streams:340
    validatePath(this.path, 'path', { expectFile: true, syscall: 'write' });
    ^

SystemError [ERR_FS_EISDIR]: Path is a directory: write returned ERR_FS_EISDIR (is a directory) /home/xxx/OpenJDK17U-jre_x64_linux_hotspot_17.0.11_9.tar.gz_extracted/jdk-17.0.11+9-jre/
``` 