### PR TITLE
SCANNPM-58 Avoid conflicts between axios's proxy option and custom http(s) agents

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -60,8 +60,8 @@ async function extractTruststoreCerts(p12Base64: string, password: string = ''):
 
 export async function getHttpAgents(
   properties: ScannerProperties,
-): Promise<Pick<AxiosRequestConfig, 'httpAgent' | 'httpsAgent'>> {
-  const agents: Pick<AxiosRequestConfig, 'httpAgent' | 'httpsAgent'> = {};
+): Promise<Pick<AxiosRequestConfig, 'httpAgent' | 'httpsAgent' | 'proxy'>> {
+  const agents: Pick<AxiosRequestConfig, 'httpAgent' | 'httpsAgent' | 'proxy'> = {};
   const proxyUrl = getProxyUrl(properties);
 
   // Accumulate https agent options
@@ -94,6 +94,7 @@ export async function getHttpAgents(
   if (proxyUrl) {
     agents.httpsAgent = new HttpsProxyAgent({ proxy: proxyUrl.toString(), ...httpsAgentOptions });
     agents.httpAgent = new HttpProxyAgent({ proxy: proxyUrl.toString() });
+    agents.proxy = false; // SCANNPM-58 Avoid conflicts between axios's proxy option and custom http(s) agents
   } else if (Object.keys(httpsAgentOptions).length > 0) {
     // Only create an agent if there are options
     agents.httpsAgent = new https.Agent({ ...httpsAgentOptions });

--- a/test/unit/request.test.ts
+++ b/test/unit/request.test.ts
@@ -48,6 +48,7 @@ describe('request', () => {
         expect(agents.httpAgent?.proxy.toString()).toBe('http://proxy.com/');
         expect(agents.httpsAgent).toBeInstanceOf(HttpsProxyAgent);
         expect(agents.httpsAgent?.proxy.toString()).toBe('http://proxy.com/');
+        expect(agents.proxy).toBe(false);
       });
 
       it('should not define agents when no proxy is provided', async () => {
@@ -56,6 +57,7 @@ describe('request', () => {
         });
         expect(agents.httpAgent).toBeUndefined();
         expect(agents.httpsAgent).toBeUndefined();
+        expect(agents.proxy).toBeUndefined();
         expect(agents).toEqual({});
       });
     });
@@ -90,12 +92,13 @@ describe('request', () => {
         const truststorePath = path.join(__dirname, 'fixtures', 'ssl', 'truststore-invalid.p12');
         const truststorePass = 'password';
 
-        const { httpsAgent } = await getHttpAgents({
+        const { proxy, httpsAgent } = await getHttpAgents({
           [ScannerProperty.SonarHostUrl]: SONARCLOUD_URL,
           [ScannerProperty.SonarScannerTruststorePath]: truststorePath,
           [ScannerProperty.SonarScannerTruststorePassword]: truststorePass,
         });
 
+        expect(proxy).toBeUndefined();
         expect(httpsAgent).toBeUndefined();
         expect(logging.log).toHaveBeenCalledWith(
           logging.LogLevel.WARN,
@@ -108,12 +111,13 @@ describe('request', () => {
         const truststorePath = path.join(__dirname, 'fixtures', 'ssl', 'truststore-empty.p12');
         const truststorePass = 'password';
 
-        const { httpsAgent } = await getHttpAgents({
+        const { proxy, httpsAgent } = await getHttpAgents({
           [ScannerProperty.SonarHostUrl]: SONARCLOUD_URL,
           [ScannerProperty.SonarScannerTruststorePath]: truststorePath,
           [ScannerProperty.SonarScannerTruststorePassword]: truststorePass,
         });
 
+        expect(proxy).toBeUndefined();
         const ca = httpsAgent?.options.ca as string[];
         expect(ca).toHaveLength(0);
       });
@@ -123,12 +127,13 @@ describe('request', () => {
         const keystorePath = path.join(__dirname, 'fixtures', 'ssl', 'keystore.p12');
         const keystorePass = 'password';
 
-        const { httpsAgent } = await getHttpAgents({
+        const { proxy, httpsAgent } = await getHttpAgents({
           [ScannerProperty.SonarHostUrl]: SONARCLOUD_URL,
           [ScannerProperty.SonarScannerKeystorePath]: keystorePath,
           [ScannerProperty.SonarScannerKeystorePassword]: keystorePass,
         });
 
+        expect(proxy).toBeUndefined();
         expect(httpsAgent?.options.pfx).toEqual(fsExtra.readFileSync(keystorePath));
         expect(httpsAgent?.options.passphrase).toBe(keystorePass);
       });
@@ -146,7 +151,7 @@ describe('request', () => {
       const keystorePath = path.join(__dirname, 'fixtures', 'ssl', 'keystore.p12');
       const keystorePass = 'password';
 
-      const { httpsAgent } = await getHttpAgents({
+      const { httpsAgent, proxy } = await getHttpAgents({
         [ScannerProperty.SonarHostUrl]: SONARCLOUD_URL,
         [ScannerProperty.SonarScannerProxyHost]: 'proxy.com',
         [ScannerProperty.SonarScannerTruststorePath]: truststorePath,
@@ -154,6 +159,8 @@ describe('request', () => {
         [ScannerProperty.SonarScannerKeystorePath]: keystorePath,
         [ScannerProperty.SonarScannerKeystorePassword]: keystorePass,
       });
+
+      expect(proxy).toBe(false);
 
       const ca = httpsAgent?.options.ca as string[];
       expect(ca).toHaveLength(1);


### PR DESCRIPTION
Fixes [SCANNPM-58](https://sonarsource.atlassian.net/browse/SCANNPM-58) reported by [this user](https://community.sonarsource.com/t/npm-sonarqube-scanner-fails-behind-proxy/130094).

I chose to set `proxy: false` the closest to where we set the HTTP[S] agents in the code

[SCANNPM-58]: https://sonarsource.atlassian.net/browse/SCANNPM-58?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ