### PR TITLE
SCANNPM-44 Trim property values to avoid misconfiguration

### DIFF
--- a/src/properties.ts
+++ b/src/properties.ts
@@ -354,7 +354,7 @@ function getBootstrapperProperties(startTimestampMs: number): ScannerProperties 
  * Get endpoint properties from scanner properties.
  */
 export function getHostProperties(properties: ScannerProperties): ScannerProperties {
-  const sonarHostUrl = properties[ScannerProperty.SonarHostUrl]?.replace(/\/$/, '');
+  const sonarHostUrl = properties[ScannerProperty.SonarHostUrl]?.replace(/\/$/, '')?.trim();
   const sonarApiBaseUrl = properties[ScannerProperty.SonarScannerApiBaseUrl];
   const sonarCloudSpecified =
     properties[ScannerProperty.SonarScannerSonarCloudUrl] === sonarHostUrl ||
@@ -427,6 +427,8 @@ function normalizeProperties(properties: ScannerProperties) {
       properties[key] = '';
     } else if (typeof value === 'undefined') {
       delete properties[key];
+    } else {
+      properties[key] = value.toString().trim();
     }
   }
 

--- a/test/unit/fixtures/fake_project_with_sonar_properties/sonar-project.properties
+++ b/test/unit/fixtures/fake_project_with_sonar_properties/sonar-project.properties
@@ -1,6 +1,9 @@
 # The following test parsing of properties file according to the specification
 # @see https://en.wikipedia.org/wiki/.properties
 
+# The following property contains a trailing space
+sonar.host.url = http://localhost:1234 
+
 # Multi-line value
 sonar.exclusions=\
   **/node_modules/**,\

--- a/test/unit/properties.test.ts
+++ b/test/unit/properties.test.ts
@@ -686,22 +686,17 @@ describe('getProperties', () => {
       projectHandler.reset('fake_project_with_sonar_properties');
       projectHandler.setEnvironmentVariables({});
 
-      const properties = getProperties(
-        {
-          serverUrl: 'http://localhost/sonarqube',
-        },
-        projectHandler.getStartTime(),
-      );
+      const properties = getProperties({}, projectHandler.getStartTime());
 
       expect(properties).toEqual({
         ...projectHandler.getExpectedProperties(),
-        'sonar.host.url': 'http://localhost/sonarqube',
-        'sonar.scanner.apiBaseUrl': 'http://localhost/sonarqube/api/v2',
+        'sonar.host.url': 'http://localhost:1234',
+        'sonar.scanner.apiBaseUrl': 'http://localhost:1234/api/v2',
         'sonar.scanner.internal.isSonarCloud': 'false',
         'sonar.exclusions': '**/node_modules/**,**/docs-dist/**',
         'sonar.scanner.dummy.path': 'C:path\toproject',
         'sonar.scanner.dummy.space.around.eq': 'value',
-        'sonar.scanner.dummy.whitespace.at.beginning': ' value',
+        'sonar.scanner.dummy.whitespace.at.beginning': 'value', // SCANNPM-44 Leading whitespaces are NOT preserved
         'sonar.scanner.empty.property': '',
       });
     });


### PR DESCRIPTION
[ticket](https://sonarsource.atlassian.net/browse/SCANNPM-44)

This shouldn't be a breaking change because we don't have any property that expects a leading/ending whitespace.