### PR TITLE
SCANNPM-49 Fix compatibility with other scanners (CLI, Scanner Engine)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,7 +33,7 @@ export const SONAR_DIR_DEFAULT = '.sonar';
 
 export const SONAR_CACHE_DIR = 'cache';
 
-export const UNARCHIVE_SUFFIX = '_extracted';
+export const UNARCHIVE_SUFFIX = '_unzip';
 
 export const SONAR_SCANNER_ALIAS = 'SonarScanner Engine';
 export const JRE_ALIAS = 'JRE';

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -53,6 +53,7 @@ function getDefaultProperties(): ScannerProperties {
       process.env.HOME ?? process.env.USERPROFILE ?? '',
       SONAR_DIR_DEFAULT,
     ),
+    [ScannerProperty.SonarWorkingDirectory]: '.scannerwork',
     [ScannerProperty.SonarScannerOs]: getSupportedOS(),
     [ScannerProperty.SonarScannerArch]: getArch(),
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export enum ScannerProperty {
   SonarExclusions = 'sonar.exclusions',
   SonarHostUrl = 'sonar.host.url',
   SonarUserHome = 'sonar.userHome',
+  SonarWorkingDirectory = 'sonar.working.directory',
   SonarScannerApiBaseUrl = 'sonar.scanner.apiBaseUrl',
   SonarScannerOs = 'sonar.scanner.os',
   SonarScannerArch = 'sonar.scanner.arch',

--- a/test/unit/file.test.ts
+++ b/test/unit/file.test.ts
@@ -256,9 +256,7 @@ describe('file', () => {
       expect(fsExtra.mkdirSync).not.toHaveBeenCalled();
 
       expect(archivePath).toEqual(path.join('/', 'sonar', 'cache', 'md5_test', 'file.txt'));
-      expect(unarchivePath).toEqual(
-        path.join('/', 'sonar', 'cache', 'md5_test', 'file.txt_extracted'),
-      );
+      expect(unarchivePath).toEqual(path.join('/', 'sonar', 'cache', 'md5_test', 'file.txt_unzip'));
     });
     it('should create the parent cache directory if it does not exist', async () => {
       jest.spyOn(fsExtra, 'existsSync').mockImplementationOnce(() => false);

--- a/test/unit/java.test.ts
+++ b/test/unit/java.test.ts
@@ -157,7 +157,7 @@ describe('java', () => {
     describe('when the JRE is not cached', () => {
       const mockCacheDirectories = {
         archivePath: '/mocked-archive-path',
-        unarchivePath: '/mocked-archive-path_extracted',
+        unarchivePath: '/mocked-archive-path_unzip',
       };
       beforeEach(() => {
         jest.spyOn(file, 'getCacheFileLocation').mockResolvedValue(null);

--- a/test/unit/mocks/FakeProjectMock.ts
+++ b/test/unit/mocks/FakeProjectMock.ts
@@ -55,6 +55,7 @@ export class FakeProjectMock {
 
   getExpectedProperties() {
     return {
+      'sonar.working.directory': '.scannerwork',
       'sonar.exclusions': DEFAULT_SONAR_EXCLUSIONS,
       'sonar.projectBaseDir': this.projectPath,
       'sonar.scanner.bootstrapStartTime': this.startTimeMs.toString(),

--- a/test/unit/properties.test.ts
+++ b/test/unit/properties.test.ts
@@ -133,6 +133,7 @@ describe('getProperties', () => {
           options: {
             'sonar.projectKey': 'use-this-project-key',
             'sonar.scanner.os': 'some-os',
+            'sonar.working.directory': '.override',
           },
         },
         projectHandler.getStartTime(),
@@ -150,6 +151,7 @@ describe('getProperties', () => {
         'sonar.projectVersion': '1.0-SNAPSHOT',
         'sonar.sources': 'the-sources',
         'sonar.scanner.os': 'some-os',
+        'sonar.working.directory': '.override',
       });
     });
 

--- a/test/unit/scanner-engine.test.ts
+++ b/test/unit/scanner-engine.test.ts
@@ -41,7 +41,7 @@ const MOCKED_PROPERTIES: ScannerProperties = {
 
 const MOCK_CACHE_DIRECTORIES = {
   archivePath: 'mocked/path/to/sonar/cache/sha_test/scanner-engine-1.2.3.jar',
-  unarchivePath: 'mocked/path/to/sonar/cache/sha_test/scanner-engine-1.2.3.jar_extracted',
+  unarchivePath: 'mocked/path/to/sonar/cache/sha_test/scanner-engine-1.2.3.jar_unzip',
 };
 jest.mock('../../src/constants', () => ({
   ...jest.requireActual('../../src/constants'),


### PR DESCRIPTION

This PR fixes 2 issues:

## sonar.working.directory

Described by this [ticket](https://sonarsource.atlassian.net/browse/SCANNPM-49):
- The default value set by the NPM Scanner is now `.scannerwork`, same as the Scanner CLI
- If a value is set by any mean, it will override this value

## archive extraction path

The path for archive extraction was different than the one for the CLI Scanner. Therefore, when:
- Cleaning the `.sonar` folder
- Analyzing a project with the CLI Scanner
- Analyzing a project with the NPM Scanner

The analysis failed because the NPM Scanner is looking for the extracted content in `~/.sonar/cache/{sha}/{filename}_extracted` where the CLI Scanner stored it in `~/.sonar/cache/{sha}/{filename}_unzip`. I've synchronized the value for both to `_unzip`. 