### PR TITLE
SCANNPM-78 Support `sonar.region`

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,6 +28,7 @@ export const SONARCLOUD_API_BASE_URL = 'https://api.sonarcloud.io';
 export const SONARCLOUD_API_BASE_URL_US = 'https://api.sonarqube.us';
 
 export const SONARCLOUD_URL_REGEX = /^(https?:\/\/)?(www\.)?(sonarcloud\.io)/;
+export const SONARCLOUD_US_URL_REGEX = /^(https?:\/\/)?(www\.)?(sonarqube\.us)/;
 
 export const REGION_US = 'us';
 export const REGIONS = [REGION_US];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,10 +22,15 @@ import { ScannerProperty } from './types';
 export const SCANNER_BOOTSTRAPPER_NAME = 'ScannerNpm';
 
 export const SONARCLOUD_URL = 'https://sonarcloud.io';
+export const SONARCLOUD_URL_US = 'https://sonarqube.us';
 
 export const SONARCLOUD_API_BASE_URL = 'https://api.sonarcloud.io';
+export const SONARCLOUD_API_BASE_URL_US = 'https://api.sonarqube.us';
 
 export const SONARCLOUD_URL_REGEX = /^(https?:\/\/)?(www\.)?(sonarcloud\.io)/;
+
+export const REGION_US = 'us';
+export const REGIONS = [REGION_US];
 
 export const SONARQUBE_JRE_PROVISIONING_MIN_VERSION = '10.6';
 

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -34,6 +34,7 @@ import {
   SONARCLOUD_API_BASE_URL,
   SONARCLOUD_URL,
   SONARCLOUD_URL_REGEX,
+  SONARCLOUD_US_URL_REGEX,
   SONAR_DIR_DEFAULT,
   SONAR_PROJECT_FILENAME,
 } from './constants';
@@ -358,9 +359,7 @@ function getBootstrapperProperties(startTimestampMs: number): ScannerProperties 
 export function getHostProperties(properties: ScannerProperties): ScannerProperties {
   const sonarHostUrl = properties[ScannerProperty.SonarHostUrl]?.replace(/\/$/, '')?.trim();
   const sonarApiBaseUrl = properties[ScannerProperty.SonarScannerApiBaseUrl];
-  const sonarCloudSpecified =
-    properties[ScannerProperty.SonarScannerSonarCloudUrl] === sonarHostUrl ||
-    SONARCLOUD_URL_REGEX.exec(sonarHostUrl ?? '');
+  const sonarCloudSpecified = isSonarCloud(properties, sonarHostUrl);
 
   if (!sonarHostUrl || sonarCloudSpecified) {
     const region = (properties[ScannerProperty.SonarRegion] ?? '').toLowerCase();
@@ -397,6 +396,12 @@ export function getHostProperties(properties: ScannerProperties): ScannerPropert
       [ScannerProperty.SonarScannerApiBaseUrl]: sonarApiBaseUrl ?? `${sonarHostUrl}/api/v2`,
     };
   }
+}
+
+function isSonarCloud(properties: ScannerProperties, sonarHostUrl: string,) {
+  return properties[ScannerProperty.SonarScannerSonarCloudUrl] === sonarHostUrl ||
+    SONARCLOUD_URL_REGEX.exec(sonarHostUrl ?? '') ||
+    SONARCLOUD_US_URL_REGEX.exec(sonarHostUrl ?? '');
 }
 
 function getHttpProxyEnvProperties(serverUrl: string): ScannerProperties {

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -366,19 +366,22 @@ export function getHostProperties(properties: ScannerProperties): ScannerPropert
     const region = (properties[ScannerProperty.SonarRegion] ?? '').toLowerCase();
     let defaultCloudUrl, defaultApiUrl;
     switch (region) {
-      case '':
+      case '': {
         defaultCloudUrl = SONARCLOUD_URL;
         defaultApiUrl = SONARCLOUD_API_BASE_URL;
         break;
-      case REGION_US:
+      }
+      case REGION_US: {
         defaultCloudUrl = 'https://sonarqube.us';
         defaultApiUrl = 'https://api.sonarqube.us';
         break;
-      default:
+      }
+      default: {
         const regionsPrint = REGIONS.map(r => `"${r}"`);
         throw new Error(
           `Unsupported region '${region}'. List of supported regions: ${regionsPrint}. Please check the '${ScannerProperty.SonarRegion}' property or the 'SONAR_REGION' environment variable.`,
         );
+      }
     }
 
     return {

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -375,7 +375,7 @@ export function getHostProperties(properties: ScannerProperties): ScannerPropert
         defaultApiUrl = 'https://api.sonarqube.us';
         break;
       default:
-        throw `Unsupported region '${region}'. List of supported regions: ${REGIONS}. Please check the 'sonar.region' property or the 'SONAR_REGION' environment variable.`;
+        throw `Unsupported region '${region}'. List of supported regions: ${REGIONS.map(r => `"${r}"`)}. Please check the 'sonar.region' property or the 'SONAR_REGION' environment variable.`;
     }
 
     return {

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -398,10 +398,12 @@ export function getHostProperties(properties: ScannerProperties): ScannerPropert
   }
 }
 
-function isSonarCloud(properties: ScannerProperties, sonarHostUrl: string,) {
-  return properties[ScannerProperty.SonarScannerSonarCloudUrl] === sonarHostUrl ||
+function isSonarCloud(properties: ScannerProperties, sonarHostUrl: string) {
+  return (
+    properties[ScannerProperty.SonarScannerSonarCloudUrl] === sonarHostUrl ||
     SONARCLOUD_URL_REGEX.exec(sonarHostUrl ?? '') ||
-    SONARCLOUD_US_URL_REGEX.exec(sonarHostUrl ?? '');
+    SONARCLOUD_US_URL_REGEX.exec(sonarHostUrl ?? '')
+  );
 }
 
 function getHttpProxyEnvProperties(serverUrl: string): ScannerProperties {

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -375,7 +375,10 @@ export function getHostProperties(properties: ScannerProperties): ScannerPropert
         defaultApiUrl = 'https://api.sonarqube.us';
         break;
       default:
-        throw `Unsupported region '${region}'. List of supported regions: ${REGIONS.map(r => `"${r}"`)}. Please check the 'sonar.region' property or the 'SONAR_REGION' environment variable.`;
+        const regionsPrint = REGIONS.map(r => `"${r}"`);
+        throw new Error(
+          `Unsupported region '${region}'. List of supported regions: ${regionsPrint}. Please check the '${ScannerProperty.SonarRegion}' property or the 'SONAR_REGION' environment variable.`,
+        );
     }
 
     return {

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -27,6 +27,8 @@ import {
   ENV_TO_PROPERTY_NAME,
   ENV_VAR_PREFIX,
   NPM_CONFIG_ENV_VAR_PREFIX,
+  REGIONS,
+  REGION_US,
   SCANNER_BOOTSTRAPPER_NAME,
   SCANNER_DEPRECATED_PROPERTIES,
   SONARCLOUD_API_BASE_URL,
@@ -361,11 +363,26 @@ export function getHostProperties(properties: ScannerProperties): ScannerPropert
     SONARCLOUD_URL_REGEX.exec(sonarHostUrl ?? '');
 
   if (!sonarHostUrl || sonarCloudSpecified) {
+    const region = (properties[ScannerProperty.SonarRegion] ?? '').toLowerCase();
+    let defaultCloudUrl, defaultApiUrl;
+    switch (region) {
+      case '':
+        defaultCloudUrl = SONARCLOUD_URL;
+        defaultApiUrl = SONARCLOUD_API_BASE_URL;
+        break;
+      case REGION_US:
+        defaultCloudUrl = 'https://sonarqube.us';
+        defaultApiUrl = 'https://api.sonarqube.us';
+        break;
+      default:
+        throw `Unsupported region '${region}'. List of supported regions: ${REGIONS}. Please check the 'sonar.region' property or the 'SONAR_REGION' environment variable.`;
+    }
+
     return {
       [ScannerProperty.SonarScannerInternalIsSonarCloud]: 'true',
       [ScannerProperty.SonarHostUrl]:
-        properties[ScannerProperty.SonarScannerSonarCloudUrl] ?? SONARCLOUD_URL,
-      [ScannerProperty.SonarScannerApiBaseUrl]: sonarApiBaseUrl ?? SONARCLOUD_API_BASE_URL,
+        properties[ScannerProperty.SonarScannerSonarCloudUrl] ?? defaultCloudUrl,
+      [ScannerProperty.SonarScannerApiBaseUrl]: sonarApiBaseUrl ?? defaultApiUrl,
     };
   } else {
     return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,7 @@ export enum ScannerProperty {
   SonarScannerArch = 'sonar.scanner.arch',
   SonarOrganization = 'sonar.organization',
   SonarProjectBaseDir = 'sonar.projectBaseDir',
+  SonarRegion = 'sonar.region',
   SonarScannerSonarCloudUrl = 'sonar.scanner.sonarcloudUrl',
   SonarScannerJavaExePath = 'sonar.scanner.javaExePath',
   SonarScannerJavaOptions = 'sonar.scanner.javaOpts',

--- a/test/unit/properties.test.ts
+++ b/test/unit/properties.test.ts
@@ -780,7 +780,7 @@ describe('getProperties', () => {
       },
     );
 
-    it('should set the "sonar.scanner.sonarcloudUrl" and "sonar.scanner.apiBaseUrl" properties when "sonar.region" is set to a supported value', () => {
+    it('should set the depending properties correctly when "sonar.region" is set to a supported value', () => {
       projectHandler.reset('whatever');
       projectHandler.setEnvironmentVariables({});
 
@@ -788,6 +788,29 @@ describe('getProperties', () => {
         {
           options: {
             [ScannerProperty.SonarRegion]: REGION_US,
+          },
+        },
+        projectHandler.getStartTime(),
+      );
+
+      expect(properties).toEqual({
+        ...projectHandler.getExpectedProperties(),
+        'sonar.host.url': 'https://sonarqube.us',
+        'sonar.scanner.apiBaseUrl': 'https://api.sonarqube.us',
+        'sonar.scanner.internal.isSonarCloud': 'true',
+        'sonar.region': 'us',
+      });
+    });
+
+    it('should set the depending properties correctly when "sonar.host.url" is set and "sonar.region" and is set to a supported value', () => {
+      projectHandler.reset('whatever');
+      projectHandler.setEnvironmentVariables({});
+
+      const properties = getProperties(
+        {
+          options: {
+            [ScannerProperty.SonarRegion]: REGION_US,
+            [ScannerProperty.SonarHostUrl]: 'https://sonarqube.us',
           },
         },
         projectHandler.getStartTime(),

--- a/test/unit/properties.test.ts
+++ b/test/unit/properties.test.ts
@@ -777,6 +777,28 @@ describe('getProperties', () => {
         });
       },
     );
+
+    it('should set the "sonar.scanner.sonarcloudUrl" and "sonar.scanner.apiBaseUrl" properties when "sonar.region" is set to a supported value', () => {
+      projectHandler.reset('whatever');
+      projectHandler.setEnvironmentVariables({});
+
+      const properties = getProperties(
+        {
+          options: {
+            [ScannerProperty.SonarRegion]: 'us',
+          },
+        },
+        projectHandler.getStartTime(),
+      );
+
+      expect(properties).toEqual({
+        ...projectHandler.getExpectedProperties(),
+        'sonar.host.url': 'https://sonarqube.us',
+        'sonar.scanner.apiBaseUrl': 'https://api.sonarqube.us',
+        'sonar.scanner.internal.isSonarCloud': 'true',
+        'sonar.region': 'us',
+      });
+    });
   });
 });
 

--- a/test/unit/properties.test.ts
+++ b/test/unit/properties.test.ts
@@ -20,6 +20,8 @@
 import sinon from 'sinon';
 import {
   DEFAULT_SONAR_EXCLUSIONS,
+  REGION_US,
+  REGIONS,
   SCANNER_BOOTSTRAPPER_NAME,
   SONARCLOUD_API_BASE_URL,
   SONARCLOUD_URL,
@@ -785,7 +787,7 @@ describe('getProperties', () => {
       const properties = getProperties(
         {
           options: {
-            [ScannerProperty.SonarRegion]: 'us',
+            [ScannerProperty.SonarRegion]: REGION_US,
           },
         },
         projectHandler.getStartTime(),
@@ -798,6 +800,25 @@ describe('getProperties', () => {
         'sonar.scanner.internal.isSonarCloud': 'true',
         'sonar.region': 'us',
       });
+    });
+
+    it('should throw an exception if "sonar.region" is set to an unsupported value', () => {
+      projectHandler.reset('whatever');
+      projectHandler.setEnvironmentVariables({});
+      const invalidRegion = "some region that doesn't exist";
+
+      expect(() =>
+        getProperties(
+          {
+            options: {
+              [ScannerProperty.SonarRegion]: invalidRegion,
+            },
+          },
+          projectHandler.getStartTime(),
+        ),
+      ).toThrow(
+        `Unsupported region '${invalidRegion}'. List of supported regions: ${REGIONS.map(r => `"${r}"`)}. Please check the '${ScannerProperty.SonarRegion}' property or the 'SONAR_REGION' environment variable.`,
+      );
     });
   });
 });


### PR DESCRIPTION
[SCANNPM-78](https://sonarsource.atlassian.net/browse/SCANNPM-78)

Similar efforts:
- https://github.com/SonarSource/sonar-scanner-msbuild/pull/2344
- https://github.com/SonarSource/sonar-scanner-gradle/pull/286
- https://github.com/SonarSource/sonar-scanner-maven/pull/284

I cannot manage to validate the support of the feature. Here are the steps I tried:
1. create an organization and project on https://sonarqube.us
2. build the scanner locally using `npm run build`
3. Execute the command like that:
```
node build/bin/sonar-scanner.js \
  -Dsonar.token=<your token> \
  -Dsonar.region=US \
  -Dsonar.organization=<your org> \
  -Dsonar.projectKey=<your project key> \
  -X
```

When executing the above code, I'm getting the following error:

```
[INFO]  Bootstrapper: JRE provisioning is supported
[DEBUG] Bootstrapper: Detecting latest version of JRE
[DEBUG] Bootstrapper: Downloading JRE information for darwin arm64 from /analysis/jres
[ERROR] Bootstrapper: An error occurred: Error: self-signed certificate in certificate chain
```

The following issue does not happen when doing the same steps against a project on https://sonarcloud.io

```
node build/bin/sonar-scanner.js \
  -Dsonar.host.url=https://sonarcloud.io \
  -Dsonar.token=<your token>\
  -Dsonar.organization=<your org> \
  -Dsonar.projectKey=<your project key>
```

[SCANNPM-78]: https://sonarsource.atlassian.net/browse/SCANNPM-78?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ