### PR TITLE
Revert "SCANNPM-80 GitHub workflows migration to self hosted runners (#203)"

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestMerged_job:
     name: Pull Request Merged
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestCreated_job:
     name: Pull Request Created
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
     # For external PR, ticket should be created manually

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   RequestReview_job:
     name: Request review
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   SubmitReview_job:
     name: Submit Review
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # required for SonarSource/vault-action-wrapper
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     env:
       RELEASE_TAG: ${{ github.event.release.tag_name }}
       RELEASE_NAME: ${{ github.event.release.name }}


### PR DESCRIPTION
[SCANNPM-80](https://sonarsource.atlassian.net/browse/SCANNPM-80)

This reverts commit b91af7b9470d06ad368c629d4841fd40e56611d9.

Self hosted runners should not be used on public repositories. Sonar-runner is only for [private and internal repositories](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/3694231566/Using+Self-Hosted+GitHub+Runners+-+GitHub#1.-Repository-access-to-the-runner).

[SCANNPM-80]: https://sonarsource.atlassian.net/browse/SCANNPM-80?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ