### PR TITLE
fix(deps): bump axios to 1.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "LGPL-3.0-only",
       "dependencies": {
         "adm-zip": "0.5.16",
-        "axios": "1.13.6",
+        "axios": "1.15.0",
         "commander": "14.0.3",
         "hpagent": "1.2.0",
         "node-forge": "1.4.0",
@@ -1811,14 +1811,23 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/b4a": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "LGPL-3.0-only",
   "dependencies": {
     "adm-zip": "0.5.16",
-    "axios": "1.13.6",
+    "axios": "1.15.0",
     "commander": "14.0.3",
     "hpagent": "1.2.0",
     "node-forge": "1.4.0",


### PR DESCRIPTION
## Summary

This PR bumps `axios` from `1.13.6` to `1.15.0` to address a known security vulnerability.

## Details

The current `master` branch depends on:

- `axios`: `1.13.6`

According to the following advisories, patched versions are `>= 1.15.0`:

- https://github.com/axios/axios/security/advisories/GHSA-fvcv-3m26-pcqx
- https://nvd.nist.gov/vuln/detail/CVE-2026-40175

## Validation

- Updated `package.json`
- Updated `package-lock.json`
- Ran test suite locally