### PR TITLE
SCANNPM-140 Configure Renovate immediate PR creation and npm monorepo grouping

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,5 +41,6 @@
     }
   ],
   "autoApprove": true,
+  "prCreation": "immediate",
   "rebaseWhen": "never"
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,9 +9,10 @@
   "ignorePaths": ["**/fixtures/**"],
   "packageRules": [
     {
-      "description": "Don't group updates",
-      "matchPackageNames": ["*"],
-      "groupName": null
+      "description": "Group npm and maven updates per source repository (monorepo), fallback to per dependency",
+      "matchManagers": ["npm", "maven"],
+      "groupName": "{{#if sourceRepo}}{{sourceRepo}} monorepo{{else}}{{depName}}{{/if}}",
+      "groupSlug": "{{#if sourceRepo}}{{sourceRepo}}{{else}}{{depName}}{{/if}}"
     },
     {
       "matchManagers": ["github-actions"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,8 +9,8 @@
   "ignorePaths": ["**/fixtures/**"],
   "packageRules": [
     {
-      "description": "Group npm and maven updates per source repository (monorepo), fallback to per dependency",
-      "matchManagers": ["npm", "maven"],
+      "description": "Group npm updates per source repository (monorepo), fallback to per dependency",
+      "matchManagers": ["npm"],
       "groupName": "{{#if sourceRepo}}{{sourceRepo}} monorepo{{else}}{{depName}}{{/if}}",
       "groupSlug": "{{#if sourceRepo}}{{sourceRepo}}{{else}}{{depName}}{{/if}}"
     },


### PR DESCRIPTION
## Summary
- set \prCreation\ to \immediate\ in Renovate config
- keeps branch creation and PR creation coupled

## Why
This avoids branch-only updates being left without PRs when checks are pending.