### PR TITLE
Disable grouping by default in Renovate (keep npm monorepo grouping)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,11 @@
   "ignorePaths": ["**/fixtures/**"],
   "packageRules": [
     {
+      "description": "Don't group updates by default",
+      "matchPackageNames": ["*"],
+      "groupName": null
+    },
+    {
       "description": "Group npm updates per source repository (monorepo), fallback to per dependency",
       "matchManagers": ["npm"],
       "groupName": "{{#if sourceRepo}}{{sourceRepo}} monorepo{{else}}{{depName}}{{/if}}",
@@ -16,9 +21,7 @@
     },
     {
       "matchManagers": ["github-actions"],
-      "pinDigests": false,
-      "groupName": "all github actions",
-      "groupSlug": "all-github-actions"
+      "pinDigests": false
     },
     {
       "matchManagers": ["github-actions"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,5 +41,6 @@
     }
   ],
   "autoApprove": true,
+  "prCreation": "immediate",
   "rebaseWhen": "never"
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,9 +9,10 @@
   "ignorePaths": ["**/fixtures/**"],
   "packageRules": [
     {
-      "description": "Don't group updates",
-      "matchPackageNames": ["*"],
-      "groupName": null
+      "description": "Group npm and maven updates per source repository (monorepo), fallback to per dependency",
+      "matchManagers": ["npm", "maven"],
+      "groupName": "{{#if sourceRepo}}{{sourceRepo}} monorepo{{else}}{{depName}}{{/if}}",
+      "groupSlug": "{{#if sourceRepo}}{{sourceRepo}}{{else}}{{depName}}{{/if}}"
     },
     {
       "matchManagers": ["github-actions"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,8 +9,8 @@
   "ignorePaths": ["**/fixtures/**"],
   "packageRules": [
     {
-      "description": "Group npm and maven updates per source repository (monorepo), fallback to per dependency",
-      "matchManagers": ["npm", "maven"],
+      "description": "Group npm updates per source repository (monorepo), fallback to per dependency",
+      "matchManagers": ["npm"],
       "groupName": "{{#if sourceRepo}}{{sourceRepo}} monorepo{{else}}{{depName}}{{/if}}",
       "groupSlug": "{{#if sourceRepo}}{{sourceRepo}}{{else}}{{depName}}{{/if}}"
     },


### PR DESCRIPTION
## Summary
- disable grouping by default for all dependency managers
- keep npm grouped by source repository (monorepo) via explicit npm rule
- remove explicit GitHub Actions grouping

## Why
This keeps npm suite grouping while ensuring all other managers are not grouped.