### PR TITLE
SCANNPM-141 Disable grouping by default in Renovate (keep npm monorepo grouping)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,11 @@
   "ignorePaths": ["**/fixtures/**"],
   "packageRules": [
     {
+      "description": "Don't group updates by default",
+      "matchPackageNames": ["*"],
+      "groupName": null
+    },
+    {
       "description": "Group npm updates per source repository (monorepo), fallback to per dependency",
       "matchManagers": ["npm"],
       "groupName": "{{#if sourceRepo}}{{sourceRepo}} monorepo{{else}}{{depName}}{{/if}}",
@@ -16,9 +21,7 @@
     },
     {
       "matchManagers": ["github-actions"],
-      "pinDigests": false,
-      "groupName": "all github actions",
-      "groupSlug": "all-github-actions"
+      "pinDigests": false
     },
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
## Summary
- disable grouping by default for all managers
- keep npm grouped by source repository (monorepo)
- remove explicit grouping for GitHub Actions updates

## Why
This keeps npm suite grouping while ensuring updates like GitHub Actions are not grouped into a single PR.