### PR TITLE
SCANNPM-142 Switch npm publish to OIDC Trusted Publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,10 @@ on:
 
 jobs:
   publish:
+    environment: release
     permissions:
       contents: read
-      id-token: write # required for SonarSource/vault-action-wrapper
+      id-token: write # required for OIDC (npm Trusted Publisher) and SonarSource/vault-action-wrapper
     runs-on: github-ubuntu-latest-s
     env:
       RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
@@ -72,9 +73,7 @@ jobs:
         id: secrets
         uses: SonarSource/vault-action-wrapper@v3
         with:
-          secrets:
-            development/artifactory/token/SonarSource-sonar-scanner-npm-promoter access_token  | promoter_access_token;
-            development/kv/data/npmjs sonartech_npm_token  | npm_token;
+          secrets: development/artifactory/token/SonarSource-sonar-scanner-npm-promoter access_token  | promoter_access_token;
 
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -84,7 +83,6 @@ jobs:
       - name: Setup the registries
         if: ${{ !inputs.dry_run }}
         run: |
-          npm config set //registry.npmjs.org/:_authToken=${{ fromJSON(steps.secrets.outputs.vault).npm_token }}
           npm config set //repox.jfrog.io/artifactory/api/npm/:_authToken=${{ fromJSON(steps.secrets.outputs.vault).promoter_access_token }}
 
       - name: Build the package
@@ -143,10 +141,10 @@ jobs:
         run: |
           cd build
           # Publish as @sonar/scan (primary package name)
-          npm publish --tag=${{ steps.npm-tag.outputs.tag }} --access=public
+          npm publish --provenance --tag=${{ steps.npm-tag.outputs.tag }} --access=public
           # Publish as sonarqube-scanner (legacy alias for backwards compatibility)
           echo $(jq '.name = "sonarqube-scanner"' package.json) > package.json
-          npm publish --tag=${{ steps.npm-tag.outputs.tag }} --access=public
+          npm publish --provenance --tag=${{ steps.npm-tag.outputs.tag }} --access=public
 
     outputs:
       description: ${{ steps.description.outputs.description }}


### PR DESCRIPTION
## Summary

- Adds `environment: release` to the `publish` job (gates deploys to semver tags via the Terraform-managed environment in `re-service-config`)
- Removes the Vault-managed `npm_token` — authentication now uses OIDC via npm Trusted Publisher
- Adds `--provenance` to both `npm publish` calls (`@sonar/scan` and `sonarqube-scanner`) for verifiable build attestations
- Artifactory publish flow is unchanged

## How to test

The `workflow_dispatch` dry run **cannot** fully test the OIDC path since all publish steps are skipped when `dry_run: true`. To properly validate:

1. Merge this PR
2. Ensure the npm Trusted Publisher is configured on npmjs.org for both `@sonar/scan` and `sonarqube-scanner` (repo: `SonarSource/sonar-scanner-npm`, environment: `release`)
3. Trigger a pre-release (e.g. `4.4.0-alpha.1`) — it will publish to the `next` npm tag, low blast radius if something goes wrong

🤖 Generated with [Claude Code](https://claude.com/claude-code)