### PR TITLE
Support ${env.VAR} interpolation in sonar-project.properties

### DIFF
--- a/src/properties.ts
+++ b/src/properties.ts
@@ -248,11 +248,32 @@ function getSonarFileProperties(projectBaseDir: string): ScannerProperties {
   try {
     const sonarPropertiesFile = path.join(projectBaseDir, SONAR_PROJECT_FILENAME);
     const data = fs.readFileSync(sonarPropertiesFile);
-    return getPropertiesFile(data) as ScannerProperties;
+    return resolveEnvVariables(getPropertiesFile(data) as ScannerProperties);
   } catch (error) {
     log(LogLevel.DEBUG, `Failed to read ${SONAR_PROJECT_FILENAME} file: ${error}`);
     return {};
   }
+}
+
+function resolveEnvVariables(properties: ScannerProperties): ScannerProperties {
+  const { process } = getDeps();
+  const { env } = process;
+  const pattern = /\$\{env\.([^}]+)\}/g;
+  const resolved: ScannerProperties = {};
+  for (const [key, value] of Object.entries(properties)) {
+    resolved[key] = (value as string).replace(pattern, (_, varName: string) => {
+      const envValue = env[varName];
+      if (typeof envValue === 'undefined') {
+        log(
+          LogLevel.WARN,
+          `Property "${key}" references undefined environment variable "${varName}"`,
+        );
+        return '';
+      }
+      return envValue;
+    });
+  }
+  return resolved;
 }
 
 /**

--- a/test/unit/fixtures/fake_project_with_env_vars_in_sonar_properties/sonar-project.properties
+++ b/test/unit/fixtures/fake_project_with_env_vars_in_sonar_properties/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey=my-project
+sonar.token=${env.MY_SONAR_TOKEN}
+sonar.projectName=${env.MY_PROJECT_NAME}
+sonar.sources=src
+sonar.scanner.proxyHost=${env.UNDEFINED_VAR}

--- a/test/unit/properties.test.ts
+++ b/test/unit/properties.test.ts
@@ -464,6 +464,37 @@ describe('getProperties', () => {
   });
 
   describe('should handle sonar-project.properties correctly', () => {
+    it('should resolve ${env.VAR} references in sonar-project.properties', () => {
+      projectHandler.reset('fake_project_with_env_vars_in_sonar_properties');
+      projectHandler.setEnvironmentVariables({
+        MY_SONAR_TOKEN: 'resolved-token',
+        MY_PROJECT_NAME: 'My Resolved Project',
+        SONAR_HOST_URL: 'http://localhost/sonarqube',
+      });
+
+      const properties = getProperties({}, projectHandler.getStartTime());
+
+      assert.strictEqual(properties['sonar.token'], 'resolved-token');
+      assert.strictEqual(properties['sonar.projectName'], 'My Resolved Project');
+    });
+
+    it('should replace ${env.VAR} with empty string and warn when the variable is undefined', () => {
+      projectHandler.reset('fake_project_with_env_vars_in_sonar_properties');
+      projectHandler.setEnvironmentVariables({
+        MY_SONAR_TOKEN: 'some-token',
+        MY_PROJECT_NAME: 'Some Project',
+        SONAR_HOST_URL: 'http://localhost/sonarqube',
+      });
+
+      const properties = getProperties({}, projectHandler.getStartTime());
+
+      assert.strictEqual(properties['sonar.scanner.proxyHost'], '');
+      assertLoggedWithLevel(
+        'WARN',
+        'Property "sonar.scanner.proxyHost" references undefined environment variable "UNDEFINED_VAR"',
+      );
+    });
+
     it('should parse sonar-project.properties properly', () => {
       projectHandler.reset('fake_project_with_sonar_properties_file');
       projectHandler.setEnvironmentVariables({});


### PR DESCRIPTION
Add support for environment variable interpolation in sonar-project.properties, matching the behavior of the sonar-scanner CLI. Values like ${env.MY_VAR} are now replaced with the corresponding environment variable at runtime.

Part of

<!--
  Only for standalone PRs without Jira issue in the PR title:
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent
-->
