### PR TITLE
SCANNPM-145 Update code owners and release Slack channel

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
-# https://xtranet-sonarsource.atlassian.net/wiki/spaces/RE/pages/2169339970/GitHub+Authentication+Authorization#CODEOWNERS
-.github/CODEOWNERS @sonarsource/quality-web-squad
-
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @sonarsource/code-quality-ci-experience-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-* @sonarsource/code-quality-ci-experience-squad
+# https://xtranet-sonarsource.atlassian.net/wiki/spaces/RE/pages/2169339970/GitHub+Authentication+Authorization#CODEOWNERS
+.github/CODEOWNERS @sonarsource/code-quality-ci-experience-squad

--- a/.github/repo-metadata.yaml
+++ b/.github/repo-metadata.yaml
@@ -1,0 +1,2 @@
+check-sca:
+  project-key: SonarSource_sonar-scanner-npm

--- a/.github/repo-metadata.yaml
+++ b/.github/repo-metadata.yaml
@@ -1,2 +1,0 @@
-check-sca:
-  project-key: SonarSource_sonar-scanner-npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ on:
       slack_channel:
         description: 'Slack channel for release notification'
         type: string
-        default: 'ask-squad-web'
+        default: 'ops-ci-experience'
 
 jobs:
   publish:
@@ -230,7 +230,7 @@ jobs:
           errors: true
           payload: |
             {
-              "channel": "${{ inputs.slack_channel || 'ask-squad-web' }}",
+              "channel": "${{ inputs.slack_channel || 'ops-ci-experience' }}",
               "attachments": [
                 {
                   "color": "#36a64f",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,4 @@
+sonar.projectKey=SonarSource_sonar-scanner-npm
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 
 # This is the name and version displayed in the SonarCloud UI.


### PR DESCRIPTION
## Summary
- update CODEOWNERS ownership for .github/CODEOWNERS to @sonarsource/code-quality-ci-experience-squad
- update release Slack notifications to use ops-ci-experience
- set sonar.projectKey so the required SCA check can discover the SonarQube project

## Testing
- git diff --check
- precommit hook: npm run license && pretty-quick --staged
- local check-sca project-key discovery using the pinned action script
- PR checks were green before the latest metadata-only CODEOWNERS scope correction