### PR TITLE
SCANNPM-113 Support default truststore location

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,6 +36,12 @@ export const SONAR_DIR_DEFAULT = '.sonar';
 
 export const SONAR_CACHE_DIR = 'cache';
 
+export const SONAR_SSL_DIR = 'ssl';
+
+export const SONAR_TRUSTSTORE_FILENAME = 'truststore.p12';
+
+export const SONAR_SCANNER_TRUSTSTORE_DEFAULT_PASSWORD = 'changeit';
+
 export const UNARCHIVE_SUFFIX = '_extracted';
 
 export const SONAR_SCANNER_ALIAS = 'SonarScanner Engine';

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -32,7 +32,10 @@ import {
   SONARCLOUD_URL_REGEX,
   SONARCLOUD_US_URL_REGEX,
   SONAR_DIR_DEFAULT,
+  SONAR_SCANNER_TRUSTSTORE_DEFAULT_PASSWORD,
+  SONAR_SSL_DIR,
   SONAR_PROJECT_FILENAME,
+  SONAR_TRUSTSTORE_FILENAME,
   SONARCLOUD_URL_US,
   SONARCLOUD_API_BASE_URL_US,
 } from './constants';
@@ -492,6 +495,45 @@ function normalizeProperties(properties: ScannerProperties) {
   return properties;
 }
 
+function getDefaultTruststoreProperties(properties: ScannerProperties): ScannerProperties {
+  const { fs } = getDeps();
+  const hasTruststorePath = Object.prototype.hasOwnProperty.call(
+    properties,
+    ScannerProperty.SonarScannerTruststorePath,
+  );
+
+  if (hasTruststorePath) {
+    return {};
+  }
+
+  const sonarUserHome = properties[ScannerProperty.SonarUserHome]?.toString().trim();
+  if (!sonarUserHome) {
+    return {};
+  }
+
+  const truststorePath = path.join(sonarUserHome, SONAR_SSL_DIR, SONAR_TRUSTSTORE_FILENAME);
+
+  if (!fs.existsSync(truststorePath)) {
+    return {};
+  }
+
+  const truststoreProperties: ScannerProperties = {
+    [ScannerProperty.SonarScannerTruststorePath]: truststorePath,
+  };
+
+  if (
+    !Object.prototype.hasOwnProperty.call(
+      properties,
+      ScannerProperty.SonarScannerTruststorePassword,
+    )
+  ) {
+    truststoreProperties[ScannerProperty.SonarScannerTruststorePassword] =
+      SONAR_SCANNER_TRUSTSTORE_DEFAULT_PASSWORD;
+  }
+
+  return truststoreProperties;
+}
+
 export function getProperties(
   scanOptions: ScanOptions,
   startTimestampMs: number,
@@ -534,6 +576,7 @@ export function getProperties(
 
   properties = hotfixDeprecatedProperties({
     ...properties,
+    ...getDefaultTruststoreProperties(properties),
     // Can't be overridden:
     ...getHostProperties(properties), // Hotfix host properties with custom SonarCloud URL
     ...getBootstrapperProperties(startTimestampMs),

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -497,10 +497,7 @@ function normalizeProperties(properties: ScannerProperties) {
 
 function getDefaultTruststoreProperties(properties: ScannerProperties): ScannerProperties {
   const { fs } = getDeps();
-  const hasTruststorePath = Object.prototype.hasOwnProperty.call(
-    properties,
-    ScannerProperty.SonarScannerTruststorePath,
-  );
+  const hasTruststorePath = Object.hasOwn(properties, ScannerProperty.SonarScannerTruststorePath);
 
   if (hasTruststorePath) {
     return {};
@@ -521,12 +518,7 @@ function getDefaultTruststoreProperties(properties: ScannerProperties): ScannerP
     [ScannerProperty.SonarScannerTruststorePath]: truststorePath,
   };
 
-  if (
-    !Object.prototype.hasOwnProperty.call(
-      properties,
-      ScannerProperty.SonarScannerTruststorePassword,
-    )
-  ) {
+  if (!Object.hasOwn(properties, ScannerProperty.SonarScannerTruststorePassword)) {
     truststoreProperties[ScannerProperty.SonarScannerTruststorePassword] =
       SONAR_SCANNER_TRUSTSTORE_DEFAULT_PASSWORD;
   }

--- a/test/unit/properties.test.ts
+++ b/test/unit/properties.test.ts
@@ -24,8 +24,11 @@ import {
   SCANNER_BOOTSTRAPPER_NAME,
   SONARCLOUD_API_BASE_URL,
   SONARCLOUD_URL,
+  SONAR_SCANNER_TRUSTSTORE_DEFAULT_PASSWORD,
+  SONAR_SSL_DIR,
+  SONAR_TRUSTSTORE_FILENAME,
 } from '../../src/constants';
-import { setDeps, resetDeps } from '../../src/deps';
+import { getDeps, setDeps, resetDeps } from '../../src/deps';
 import { getHostProperties, getProperties } from '../../src/properties';
 import { CacheStatus, type ScannerProperties, ScannerProperty } from '../../src/types';
 import { createMockProcessDeps } from './test-helpers';
@@ -173,6 +176,19 @@ function assertProperties(actual: ScannerProperties, expected: ScannerProperties
   // Compare the rest
   const { 'sonar.userHome': _actualUserHome, ...actualRest } = actual;
   assert.deepStrictEqual(actualRest, expected);
+}
+
+function mockExistingDefaultTruststore(truststorePath: string): void {
+  const fsDeps = getDeps().fs;
+  const processDeps = getDeps().process;
+  const realExistsSync = fsDeps.existsSync;
+  setDeps({
+    process: processDeps,
+    fs: {
+      ...fsDeps,
+      existsSync: mock.fn(filePath => filePath === truststorePath || realExistsSync(filePath)),
+    },
+  });
 }
 
 describe('getProperties', () => {
@@ -791,6 +807,101 @@ describe('getProperties', () => {
       const properties = getProperties({}, projectHandler.getStartTime());
 
       assert.strictEqual(properties['sonar.scanner.mirror'], 'https://mirror.com/');
+    });
+  });
+
+  describe('should handle the default truststore', () => {
+    it('should use the truststore from the default sonar user home location when it exists', () => {
+      projectHandler.reset('fake_project_with_sonar_properties_file');
+      projectHandler.setEnvironmentVariables({
+        SONAR_USER_HOME: '/tmp/.sonar',
+      });
+      const truststorePath = path.join('/tmp/.sonar', SONAR_SSL_DIR, SONAR_TRUSTSTORE_FILENAME);
+      mockExistingDefaultTruststore(truststorePath);
+
+      const properties = getProperties({}, projectHandler.getStartTime());
+
+      assertProperties(properties, {
+        ...projectHandler.getExpectedProperties(),
+        'sonar.host.url': SONARCLOUD_URL,
+        'sonar.scanner.apiBaseUrl': SONARCLOUD_API_BASE_URL,
+        'sonar.scanner.internal.isSonarCloud': 'true',
+        'sonar.projectKey': 'foo',
+        'sonar.projectName': 'Foo',
+        'sonar.projectVersion': '1.0-SNAPSHOT',
+        'sonar.sources': 'the-sources',
+        'sonar.userHome': '/tmp/.sonar',
+        'sonar.scanner.truststorePath': truststorePath,
+        'sonar.scanner.truststorePassword': SONAR_SCANNER_TRUSTSTORE_DEFAULT_PASSWORD,
+      });
+    });
+
+    it('should not use the default truststore location when a truststore path is configured', () => {
+      projectHandler.reset('fake_project_with_sonar_properties_file');
+      projectHandler.setEnvironmentVariables({
+        SONAR_USER_HOME: '/tmp/.sonar',
+      });
+      const defaultTruststorePath = path.join(
+        '/tmp/.sonar',
+        SONAR_SSL_DIR,
+        SONAR_TRUSTSTORE_FILENAME,
+      );
+      const configuredTruststorePath = '/tmp/custom-truststore.p12';
+      mockExistingDefaultTruststore(defaultTruststorePath);
+
+      const properties = getProperties(
+        {
+          options: {
+            [ScannerProperty.SonarScannerTruststorePath]: configuredTruststorePath,
+          },
+        },
+        projectHandler.getStartTime(),
+      );
+
+      assertProperties(properties, {
+        ...projectHandler.getExpectedProperties(),
+        'sonar.host.url': SONARCLOUD_URL,
+        'sonar.scanner.apiBaseUrl': SONARCLOUD_API_BASE_URL,
+        'sonar.scanner.internal.isSonarCloud': 'true',
+        'sonar.projectKey': 'foo',
+        'sonar.projectName': 'Foo',
+        'sonar.projectVersion': '1.0-SNAPSHOT',
+        'sonar.sources': 'the-sources',
+        'sonar.userHome': '/tmp/.sonar',
+        'sonar.scanner.truststorePath': configuredTruststorePath,
+      });
+    });
+
+    it('should not override the configured truststore password for the default truststore', () => {
+      projectHandler.reset('fake_project_with_sonar_properties_file');
+      projectHandler.setEnvironmentVariables({
+        SONAR_USER_HOME: '/tmp/.sonar',
+      });
+      const truststorePath = path.join('/tmp/.sonar', SONAR_SSL_DIR, SONAR_TRUSTSTORE_FILENAME);
+      mockExistingDefaultTruststore(truststorePath);
+
+      const properties = getProperties(
+        {
+          options: {
+            [ScannerProperty.SonarScannerTruststorePassword]: 'sonar',
+          },
+        },
+        projectHandler.getStartTime(),
+      );
+
+      assertProperties(properties, {
+        ...projectHandler.getExpectedProperties(),
+        'sonar.host.url': SONARCLOUD_URL,
+        'sonar.scanner.apiBaseUrl': SONARCLOUD_API_BASE_URL,
+        'sonar.scanner.internal.isSonarCloud': 'true',
+        'sonar.projectKey': 'foo',
+        'sonar.projectName': 'Foo',
+        'sonar.projectVersion': '1.0-SNAPSHOT',
+        'sonar.sources': 'the-sources',
+        'sonar.userHome': '/tmp/.sonar',
+        'sonar.scanner.truststorePath': truststorePath,
+        'sonar.scanner.truststorePassword': 'sonar',
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Implements SCANNPM-113 by making the npm scanner honor the documented default truststore location:

- Detects `$SONAR_USER_HOME/ssl/truststore.p12` after `sonar.userHome` has been resolved.
- Sets `sonar.scanner.truststorePath` to that default path only when the file exists.
- Applies the documented default truststore password `changeit` when a default truststore is found and no password was configured.
- Preserves explicit `sonar.scanner.truststorePath` and `sonar.scanner.truststorePassword` values.

This closes the behavior gap where the npm scanner could load an explicitly configured truststore, but did not automatically discover the default location documented for scanners.

Community report: https://community.sonarsource.com/t/sonarqube-scanner-npm-cant-download-binaries-when-using-truststore-for-custom-ca/133152

## Implementation Notes

The default is resolved in property construction rather than request-time TLS setup, so the resolved scanner properties remain visible to both the Node bootstrapper and downstream scanner execution.

The default is only added when the file exists. This avoids passing a missing default path into the existing truststore loading path, which would otherwise fail while initializing HTTP agents.

## Tests

Added unit coverage for:

- Default truststore discovery under `SONAR_USER_HOME`.
- Explicit truststore path taking precedence over the default location.
- Explicit truststore password taking precedence over the default `changeit` password.

Verification run locally:

- `npx prettier --check src/constants.ts src/properties.ts test/unit/properties.test.ts`
- `npx tsx --test test/unit/properties.test.ts`
- `npm test` pass, 142/142 tests

Known existing local TypeScript check issues on fresh `origin/master`:

- `npx tsc --noEmit -p tsconfig.json` fails at `src/runner.ts(19,25)` because `commander` is ESM while the current config emits CommonJS imports.
- `npx tsc --noEmit -p test/unit/tsconfig.json` fails with existing unit `rootDir` / exported type / mock typing issues.
