### PR TITLE
SCANNPM-98 Support local scanner engine path

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -34,6 +34,7 @@ export interface Dependencies {
   // File system operations
   fs: {
     existsSync: typeof fs.existsSync;
+    statSync: typeof fs.statSync;
     readFileSync: typeof fs.readFileSync;
     readFile: typeof fs.readFile;
     mkdirSync: typeof fs.mkdirSync;
@@ -83,6 +84,7 @@ function createDefaultDeps(): Dependencies {
   return {
     fs: {
       existsSync: fs.existsSync,
+      statSync: fs.statSync,
       readFileSync: fs.readFileSync,
       readFile: fs.readFile,
       mkdirSync: fs.mkdirSync,

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -75,6 +75,12 @@ async function runScan(scanOptions: ScanOptions, cliArgs?: CliArgs) {
   log(LogLevel.INFO, `JRE provisioning ${supportsJREProvisioning ? 'is' : 'is NOT'} supported`);
 
   if (!supportsJREProvisioning) {
+    if (properties[ScannerProperty.SonarScannerEngineJarPath]) {
+      log(
+        LogLevel.WARN,
+        `Property "${ScannerProperty.SonarScannerEngineJarPath}" is set but will be ignored because JRE provisioning is not supported`,
+      );
+    }
     log(LogLevel.INFO, 'Falling back on using sonar-scanner-cli');
     if (scanOptions.localScannerCli) {
       log(LogLevel.INFO, 'Local scanner is requested, will not download sonar-scanner-cli');

--- a/src/scanner-engine.ts
+++ b/src/scanner-engine.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
+import path from 'node:path';
 import { API_V2_SCANNER_ENGINE_ENDPOINT, SONAR_SCANNER_ALIAS } from './constants';
 import { getDeps } from './deps';
 import { getCacheDirectories, getCacheFileLocation, validateChecksum } from './file';
@@ -28,6 +29,11 @@ import {
 } from './types';
 
 export async function fetchScannerEngine(properties: ScannerProperties) {
+  const localScannerEnginePath = getLocalScannerEnginePath(properties);
+  if (localScannerEnginePath) {
+    return localScannerEnginePath;
+  }
+
   const { fs, http } = getDeps();
 
   log(LogLevel.DEBUG, `Detecting latest version of ${SONAR_SCANNER_ALIAS}`);
@@ -70,6 +76,48 @@ export async function fetchScannerEngine(properties: ScannerProperties) {
   }
 
   return archivePath;
+}
+
+function getLocalScannerEnginePath(properties: ScannerProperties): string | undefined {
+  const scannerEngineJarPath = properties[ScannerProperty.SonarScannerEngineJarPath];
+  if (scannerEngineJarPath === undefined) {
+    return undefined;
+  }
+
+  const { fs } = getDeps();
+  const absoluteScannerEngineJarPath = path.resolve(scannerEngineJarPath);
+  try {
+    const stat = fs.statSync(absoluteScannerEngineJarPath);
+    if (!stat.isFile()) {
+      throw scannerEngineJarPathDoesNotExist(scannerEngineJarPath);
+    }
+
+    log(LogLevel.INFO, `Using the configured ${SONAR_SCANNER_ALIAS}`, absoluteScannerEngineJarPath);
+    delete properties[ScannerProperty.SonarScannerWasEngineCacheHit];
+    return absoluteScannerEngineJarPath;
+  } catch (error) {
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      throw scannerEngineJarPathDoesNotExist(scannerEngineJarPath);
+    }
+    if (error instanceof ScannerEngineJarPathError) {
+      throw error;
+    }
+    throw new Error(
+      `Failed to access Scanner Engine jar path '${scannerEngineJarPath}': ${error instanceof Error ? error.message : error}. Please check property '${ScannerProperty.SonarScannerEngineJarPath}'.`,
+    );
+  }
+}
+
+class ScannerEngineJarPathError extends Error {}
+
+function scannerEngineJarPathDoesNotExist(scannerEngineJarPath: string): Error {
+  return new ScannerEngineJarPathError(
+    `Scanner Engine jar path '${scannerEngineJarPath}' does not exist. Please check property '${ScannerProperty.SonarScannerEngineJarPath}'.`,
+  );
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
 }
 
 async function logOutput(message: string) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,7 @@ export enum ScannerProperty {
   SonarRegion = 'sonar.region',
   SonarScannerSonarCloudUrl = 'sonar.scanner.sonarcloudUrl',
   SonarScannerJavaExePath = 'sonar.scanner.javaExePath',
+  SonarScannerEngineJarPath = 'sonar.scanner.engineJarPath',
   SonarScannerJavaOptions = 'sonar.scanner.javaOpts',
   SonarScannerWasJreCacheHit = 'sonar.scanner.wasJreCacheHit',
   SonarScannerWasEngineCacheHit = 'sonar.scanner.wasEngineCacheHit',

--- a/test/unit/scan.test.ts
+++ b/test/unit/scan.test.ts
@@ -163,6 +163,21 @@ describe('scan', () => {
       );
     });
 
+    it('should warn when the scanner engine path is ignored', async () => {
+      mockServerSupportsJREProvisioning.mock.mockImplementation(() => Promise.resolve(false));
+
+      await scan({
+        serverUrl: 'http://localhost:9000',
+        options: { [ScannerProperty.SonarScannerEngineJarPath]: '/path/to/scanner-engine.jar' },
+      });
+
+      assertLogged(
+        `Property "${ScannerProperty.SonarScannerEngineJarPath}" is set but will be ignored`,
+      );
+      assert.strictEqual(mockFetchScannerEngine.mock.callCount(), 0);
+      assert.strictEqual(mockRunScannerCli.mock.callCount(), 1);
+    });
+
     it('should use local scanner if requested', async () => {
       mockServerSupportsJREProvisioning.mock.mockImplementation(() => Promise.resolve(false));
       mockLocateExecutableFromPath.mock.mockImplementation(() =>

--- a/test/unit/scanner-engine.test.ts
+++ b/test/unit/scanner-engine.test.ts
@@ -17,6 +17,7 @@
 
 import { describe, it, beforeEach, afterEach, mock, type Mock } from 'node:test';
 import assert from 'node:assert';
+import path from 'node:path';
 import { setDeps, resetDeps, type Dependencies } from '../../src/deps';
 import { fetchScannerEngine, runScannerEngine } from '../../src/scanner-engine';
 import {
@@ -54,6 +55,95 @@ afterEach(() => {
 
 describe('scanner-engine', () => {
   describe('fetchScannerEngine', () => {
+    it('should use the configured local scanner engine', async () => {
+      const scannerEngineJarPath = 'scanner-engine.jar';
+      const mockDownload = mock.fn(() => Promise.resolve());
+      const mockFetch = mock.fn(() => Promise.resolve({ data: SCANNER_ENGINE_RESPONSE }));
+      const mockStatSync = mock.fn(() => ({ isFile: () => true }));
+      const properties = {
+        ...MOCKED_PROPERTIES,
+        [ScannerProperty.SonarScannerEngineJarPath]: scannerEngineJarPath,
+        [ScannerProperty.SonarScannerWasEngineCacheHit]: 'false',
+      };
+
+      setDeps({
+        fs: createMockFsDeps({
+          statSync: mockStatSync as any,
+        }),
+        http: createMockHttpDeps({
+          fetch: mockFetch as any,
+          download: mockDownload,
+        }),
+      });
+
+      const result = await fetchScannerEngine(properties);
+
+      assert.strictEqual(result, path.resolve(scannerEngineJarPath));
+      assert.strictEqual(mockStatSync.mock.callCount(), 1);
+      assert.strictEqual(
+        mockStatSync.mock.calls[0].arguments[0],
+        path.resolve(scannerEngineJarPath),
+      );
+      assert.strictEqual(mockFetch.mock.callCount(), 0);
+      assert.strictEqual(mockDownload.mock.callCount(), 0);
+      assert.strictEqual(properties[ScannerProperty.SonarScannerWasEngineCacheHit], undefined);
+    });
+
+    it('should fail when the configured local scanner engine does not exist', async () => {
+      const mockDownload = mock.fn(() => Promise.resolve());
+      const mockFetch = mock.fn(() => Promise.resolve({ data: SCANNER_ENGINE_RESPONSE }));
+
+      setDeps({
+        fs: createMockFsDeps({
+          statSync: mock.fn(() => ({ isFile: () => false })) as any,
+        }),
+        http: createMockHttpDeps({
+          fetch: mockFetch as any,
+          download: mockDownload,
+        }),
+      });
+
+      await assert.rejects(
+        fetchScannerEngine({
+          ...MOCKED_PROPERTIES,
+          [ScannerProperty.SonarScannerEngineJarPath]: 'missing-engine.jar',
+        }),
+        /Scanner Engine jar path 'missing-engine.jar' does not exist. Please check property 'sonar.scanner.engineJarPath'./,
+      );
+
+      assert.strictEqual(mockFetch.mock.callCount(), 0);
+      assert.strictEqual(mockDownload.mock.callCount(), 0);
+    });
+
+    it('should include the stat error when the configured local scanner engine cannot be accessed', async () => {
+      const mockDownload = mock.fn(() => Promise.resolve());
+      const mockFetch = mock.fn(() => Promise.resolve({ data: SCANNER_ENGINE_RESPONSE }));
+      const statError = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+
+      setDeps({
+        fs: createMockFsDeps({
+          statSync: mock.fn(() => {
+            throw statError;
+          }) as any,
+        }),
+        http: createMockHttpDeps({
+          fetch: mockFetch as any,
+          download: mockDownload,
+        }),
+      });
+
+      await assert.rejects(
+        fetchScannerEngine({
+          ...MOCKED_PROPERTIES,
+          [ScannerProperty.SonarScannerEngineJarPath]: 'restricted-engine.jar',
+        }),
+        /Failed to access Scanner Engine jar path 'restricted-engine.jar': permission denied. Please check property 'sonar.scanner.engineJarPath'./,
+      );
+
+      assert.strictEqual(mockFetch.mock.callCount(), 0);
+      assert.strictEqual(mockDownload.mock.callCount(), 0);
+    });
+
     it('should fetch the latest version of the scanner engine', async () => {
       const mockDownload = mock.fn(() => Promise.resolve());
       const mockRemove = mock.fn(() => Promise.resolve());

--- a/test/unit/test-helpers.ts
+++ b/test/unit/test-helpers.ts
@@ -61,6 +61,7 @@ export function fixturePath(fixtureName: string): string {
 export function createMockFsDeps(overrides: Partial<Dependencies['fs']> = {}): Dependencies['fs'] {
   return {
     existsSync: mock.fn(() => false),
+    statSync: mock.fn(() => ({ isFile: () => false })),
     readFileSync: mock.fn(() => Buffer.from('')),
     readFile: mock.fn((path: string, cb: (err: Error | null, data: Buffer) => void) =>
       cb(null, Buffer.from('')),


### PR DESCRIPTION
## Summary
- add support for `sonar.scanner.engineJarPath` to use a local Scanner Engine JAR
- skip Scanner Engine metadata/download when the local JAR path is configured
- warn when the property is set but ignored because the scan falls back to `sonar-scanner-cli`
- validate the configured path and preserve useful filesystem access errors
- omit the engine cache-hit stat for local-engine runs

## Verification
- `npx tsx --test --test-reporter=spec test/unit/scanner-engine.test.ts`
- `npx tsx --test --test-reporter=spec test/unit/scan.test.ts`
- `npm test`
- `npm run build`
- `git diff --check`