### PR TITLE
SCANNPM-85 Improve logs to display NPM scanner

### DIFF
--- a/src/scan.ts
+++ b/src/scan.ts
@@ -68,6 +68,7 @@ async function runScan(scanOptions: ScanOptions, cliArgs?: CliArgs) {
   await initializeAxios(properties);
 
   log(LogLevel.INFO, `Server URL: ${properties[ScannerProperty.SonarHostUrl]}`);
+  log(LogLevel.INFO, 'Using SonarScanner for NPM (@sonar/scan)');
   log(LogLevel.INFO, `Version: ${version}`);
 
   log(LogLevel.DEBUG, 'Check if Server supports JRE provisioning');

--- a/test/unit/scan.test.ts
+++ b/test/unit/scan.test.ts
@@ -147,6 +147,13 @@ describe('scan', () => {
     assertLogged('Version:', 'SNAPSHOT');
   });
 
+  it('should output that the NPM scanner is being used', async () => {
+    mockServerSupportsJREProvisioning.mock.mockImplementation(() => Promise.resolve(false));
+
+    await scan({});
+    assertLogged('Using SonarScanner for NPM (@sonar/scan)');
+  });
+
   it('should output the current platform', async () => {
     mockServerSupportsJREProvisioning.mock.mockImplementation(() => Promise.resolve(false));
 


### PR DESCRIPTION
New log added just before showing the Version: "Using SonarScanner for NPM (@sonar/scan)"

<img width="583" height="92" alt="SCANNPM-85" src="https://github.com/user-attachments/assets/b5dbab5a-cb85-49ca-a64c-6d00166e19f0" />

----
## Summary by Gitar

- **Logging improvements:**
  - Added an info log entry identifying `SonarScanner for NPM` in `src/scan.ts`.
  - Added unit test coverage in `test/unit/scan.test.ts` to verify the new scanner log output.

<sub>This will update automatically on new commits.</sub>