### PR TITLE
SCANNPM-149 Remove legacy scanner executable aliases in v5

### DIFF
--- a/.pmgrc.toml
+++ b/.pmgrc.toml
@@ -19,8 +19,7 @@ version = "SNAPSHOT"
 url = "https://community.sonarsource.com/tag/scanner"
 
 [data.bin]
-sonar = "bin/sonar-scanner.js"
-sonar-scanner = "bin/sonar-scanner.js"
+sonar-scanner-npm = "bin/sonar-scanner.js"
 
 [data.engines]
 node = ">=22.12.0"

--- a/README.md
+++ b/README.md
@@ -35,13 +35,17 @@ npm install -g @sonar/scan
 
 ## Getting Started
 
-If you want to run an analysis without having to configure anything in the first place, simply run the `sonar` command. The following
-example assumes that you have installed SonarQube Server locally:
+If you want to run an analysis without having to configure anything in the first place,
+simply run the `sonar-scanner-npm` command. The following example assumes that you have
+installed SonarQube Server locally:
 
 ```
 cd my-project
-sonar
+sonar-scanner-npm
 ```
+
+The deprecated `sonar` and `sonar-scanner` executable aliases were removed in v5. Update
+global invocations and package scripts to use `sonar-scanner-npm` instead.
 
 or you can use `npx` without installing:
 

--- a/test/integration/scanner.test.ts
+++ b/test/integration/scanner.test.ts
@@ -17,6 +17,7 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
@@ -83,10 +84,18 @@ describe('scanner', { timeout: TIMEOUT_MS }, () => {
 
   it('should run an analysis via CLI', async () => {
     const projectKey = await createProject();
+    const packageBinDir = path.join(__dirname, 'node_modules', '.bin');
+    for (const removedExecutable of ['sonar', 'sonar-scanner']) {
+      assert.ok(
+        !fs.existsSync(path.join(packageBinDir, removedExecutable)),
+        `Expected the ${removedExecutable} executable not to be installed`,
+      );
+    }
     // Use the locally installed package bin to ensure we test the right version
-    const sonarBin = path.join(__dirname, 'node_modules', '.bin', 'sonar');
+    const sonarScannerNpmBin = path.join(packageBinDir, 'sonar-scanner-npm');
+    assert.ok(fs.existsSync(sonarScannerNpmBin), 'Expected sonar-scanner-npm to be installed');
     execSync(
-      `"${sonarBin}" ` +
+      `"${sonarScannerNpmBin}" ` +
         `-Dsonar.host.url=${SONAR_HOST_URL} ` +
         `-Dsonar.token=${token} ` +
         `-Dsonar.projectKey=${projectKey} ` +


### PR DESCRIPTION
## Summary

- publish only the `sonar-scanner-npm` executable from the v5 package
- remove the conflicting `sonar` and `sonar-scanner` aliases
- update the README migration guidance and default CLI example
- make the integration test verify that the legacy aliases are absent

This is the v5 removal step from [SCANNPM-149](https://sonarsource.atlassian.net/browse/SCANNPM-149). It should remain draft until the 4.4 compatibility release has introduced `sonar-scanner-npm` to Node 18/20 users.

## Compatibility

- `npx @sonar/scan` remains unchanged
- JavaScript API usage remains unchanged
- users of global executables or package scripts must migrate to `sonar-scanner-npm`

## Validation

- `mise exec -- npm run build`
- `mise exec -- npm test` — 150 tests passed
- `mise exec -- npm run check-format`
- `mise exec -- npx tsc --noEmit -p tsconfig.json`
- `mise exec -- npx knip`
- packed-tarball smoke test confirmed that only `sonar-scanner-npm` is installed
- packed-tarball smoke test confirmed that `npx @sonar/scan --version` still works

[SCANNPM-149]: https://sonarsource.atlassian.net/browse/SCANNPM-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ