### PR TITLE
SCANNPM-149 Add NPM-specific scanner executable for v4

### DIFF
--- a/.pmgrc.toml
+++ b/.pmgrc.toml
@@ -18,6 +18,7 @@ version = "SNAPSHOT"
 url = "https://community.sonarsource.com/tag/scanner"
 
 [data.bin]
+sonar-scanner-npm = "bin/sonar-scanner.js"
 sonar = "bin/sonar-scanner.js"
 sonar-scanner = "bin/sonar-scanner.js"
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,17 @@ npm install -g @sonar/scan
 
 ## Getting Started
 
-If you want to run an analysis without having to configure anything in the first place, simply run the `sonar` command. The following
-example assumes that you have installed SonarQube Server locally:
+If you want to run an analysis without having to configure anything in the first place,
+simply run the `sonar-scanner-npm` command. The following example assumes that you have
+installed SonarQube Server locally:
 
 ```
 cd my-project
-sonar
+sonar-scanner-npm
 ```
+
+> **Deprecation notice:** The `sonar` and `sonar-scanner` executable aliases are
+> deprecated and will be removed in v5. Use `sonar-scanner-npm` instead.
 
 or you can use `npx` without installing:
 

--- a/test/integration/package-lock.json
+++ b/test/integration/package-lock.json
@@ -476,6 +476,7 @@
         "tar-stream": "3.1.7"
       },
       "bin": {
+        "sonar-scanner-npm": "bin/sonar-scanner.js",
         "sonar": "bin/sonar-scanner.js",
         "sonar-scanner": "bin/sonar-scanner.js"
       },

--- a/test/integration/scanner.test.ts
+++ b/test/integration/scanner.test.ts
@@ -17,6 +17,7 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
@@ -83,10 +84,16 @@ describe('scanner', { timeout: TIMEOUT_MS }, () => {
 
   it('should run an analysis via CLI', async () => {
     const projectKey = await createProject();
+    for (const executable of ['sonar', 'sonar-scanner', 'sonar-scanner-npm']) {
+      assert.ok(
+        fs.existsSync(path.join(__dirname, 'node_modules', '.bin', executable)),
+        `Expected the ${executable} executable to be installed`,
+      );
+    }
     // Use the locally installed package bin to ensure we test the right version
-    const sonarBin = path.join(__dirname, 'node_modules', '.bin', 'sonar');
+    const sonarScannerNpmBin = path.join(__dirname, 'node_modules', '.bin', 'sonar-scanner-npm');
     execSync(
-      `"${sonarBin}" ` +
+      `"${sonarScannerNpmBin}" ` +
         `-Dsonar.host.url=${SONAR_HOST_URL} ` +
         `-Dsonar.token=${token} ` +
         `-Dsonar.projectKey=${projectKey} ` +


### PR DESCRIPTION
## Summary

- add `sonar-scanner-npm` as the preferred executable on the Node 18-compatible v4 line
- retain `sonar` and `sonar-scanner` as deprecated compatibility aliases
- update the README to recommend `sonar-scanner-npm` and announce removal of both legacy aliases in v5
- run the integration scan through the new executable while asserting all three v4 shims are installed

This is the 4.4 compatibility step from [SCANNPM-149](https://sonarsource.atlassian.net/browse/SCANNPM-149). The corresponding v5 removal is tracked in draft PR #602.

## Compatibility

- existing v4 executable invocations continue to work
- `npx @sonar/scan` remains unchanged
- JavaScript API usage remains unchanged
- Node 18 and Node 20 users gain a collision-free migration path before v5

## Validation

- `mise exec -- npm run build`
- `mise exec -- npm test` — 139 tests passed
- `mise exec -- npx knip`
- generated manifest contains all three aliases
- packed-tarball smoke test confirmed all three executables report `SNAPSHOT`
- packed-tarball smoke test confirmed `npx @sonar/scan --version` still works

[SCANNPM-149]: https://sonarsource.atlassian.net/browse/SCANNPM-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ