### PR TITLE
Fix CVE-2026-76845 in ZIP extraction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "SNAPSHOT",
       "license": "LGPL-3.0-only",
       "dependencies": {
-        "adm-zip": "0.6.0",
         "axios": "1.19.0",
         "commander": "15.0.0",
         "hpagent": "1.2.0",
@@ -18,7 +17,8 @@
         "proxy-from-env": "2.1.0",
         "semver": "7.8.5",
         "slugify": "1.6.9",
-        "tar-stream": "3.2.0"
+        "tar-stream": "3.2.0",
+        "unzipper": "0.12.5"
       },
       "devDependencies": {
         "@types/node": "24.13.3",
@@ -26,6 +26,7 @@
         "@types/proxy-from-env": "1.0.4",
         "@types/semver": "7.8.0",
         "@types/tar-stream": "3.1.4",
+        "@types/unzipper": "0.10.11",
         "@typescript-eslint/parser": "8.67.0",
         "c8": "12.0.0",
         "eslint": "10.8.1",
@@ -1500,6 +1501,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/unzipper": {
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/@types/unzipper/-/unzipper-0.10.11.tgz",
+      "integrity": "sha512-D25im2zjyMCcgL9ag6N46+wbtJBnXIr7SI4zHf9eJD2Dw2tEB5e+p5MYkrxKIVRscs5QV0EhtU9rgXSPx90oJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.67.0",
       "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/@typescript-eslint/parser/-/parser-8.67.0.tgz",
@@ -1663,15 +1674,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/adm-zip": {
-      "version": "0.6.0",
-      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/adm-zip/-/adm-zip-0.6.0.tgz",
-      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -1862,6 +1864,12 @@
         "bare-path": "^3.0.0"
       }
     },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -1988,6 +1996,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2048,6 +2062,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
       }
     },
     "node_modules/emoji-regex": {
@@ -2544,6 +2567,20 @@
         "node": ">=18.3.0"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2704,6 +2741,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
@@ -2818,6 +2861,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2840,6 +2889,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2933,6 +2988,18 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/jsx-ast-utils-x": {
       "version": "0.1.0",
@@ -3133,6 +3200,12 @@
       "engines": {
         "node": ">= 6.13.0"
       }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "license": "MIT"
     },
     "node_modules/node-reporter-sonarqube": {
       "version": "1.0.3",
@@ -3464,6 +3537,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/properties-file": {
       "version": "5.0.6",
       "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/properties-file/-/properties-file-5.0.6.tgz",
@@ -3490,6 +3569,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/refa": {
@@ -3528,6 +3622,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/scslre": {
       "version": "0.3.0",
@@ -3610,6 +3710,15 @@
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-width": {
@@ -3831,6 +3940,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.5.tgz",
+      "integrity": "sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==",
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "~3.7.2",
+        "duplexer2": "~0.1.4",
+        "fs-extra": "11.3.1",
+        "graceful-fs": "^4.2.2",
+        "node-int64": "^0.4.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3840,6 +3971,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "license": "LGPL-3.0-only",
   "dependencies": {
-    "adm-zip": "0.6.0",
     "axios": "1.19.0",
     "commander": "15.0.0",
     "hpagent": "1.2.0",
@@ -24,7 +23,8 @@
     "proxy-from-env": "2.1.0",
     "semver": "7.8.5",
     "slugify": "1.6.9",
-    "tar-stream": "3.2.0"
+    "tar-stream": "3.2.0",
+    "unzipper": "0.12.5"
   },
   "devDependencies": {
     "@types/node": "24.13.3",
@@ -32,6 +32,7 @@
     "@types/proxy-from-env": "1.0.4",
     "@types/semver": "7.8.0",
     "@types/tar-stream": "3.1.4",
+    "@types/unzipper": "0.10.11",
     "@typescript-eslint/parser": "8.67.0",
     "c8": "12.0.0",
     "eslint": "10.8.1",

--- a/src/file.ts
+++ b/src/file.ts
@@ -99,22 +99,31 @@ export async function extractArchive(fromPath: string, toPath: string) {
 async function extractZipArchive(fromPath: string, toPath: string) {
   const destinationPath = path.resolve(toPath);
   const zip = await unzipper.Open.file(fromPath);
+  const checkedPaths = new Set<string>();
 
   for (const entry of zip.files) {
-    const entryPath = path.resolve(destinationPath, entry.path.replaceAll('\\', '/'));
+    const entryPath = path.join(destinationPath, entry.path.replaceAll('\\', '/'));
     const relativePath = path.relative(destinationPath, entryPath);
-    if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    if (relativePath === '') {
+      continue;
+    }
+    if (
+      relativePath === '..' ||
+      relativePath.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relativePath)
+    ) {
       throw new Error(`Entry "${entry.path}" would extract outside target directory`);
     }
 
     for (
       let currentPath = entryPath;
-      currentPath !== destinationPath;
+      currentPath !== destinationPath && !checkedPaths.has(currentPath);
       currentPath = path.dirname(currentPath)
     ) {
       if (lstatSync(currentPath, { throwIfNoEntry: false })?.isSymbolicLink()) {
         throw new Error(`Entry "${entry.path}" would extract through a symbolic link`);
       }
+      checkedPaths.add(currentPath);
     }
   }
 
@@ -123,7 +132,10 @@ async function extractZipArchive(fromPath: string, toPath: string) {
   // unzipper does not preserve Unix permissions stored in ZIP metadata.
   // Restore them so scanner and JRE launchers remain executable.
   for (const entry of zip.files) {
-    const entryPath = path.resolve(destinationPath, entry.path.replaceAll('\\', '/'));
+    const entryPath = path.join(destinationPath, entry.path.replaceAll('\\', '/'));
+    if (entryPath === destinationPath) {
+      continue;
+    }
     const mode = (entry.externalFileAttributes >>> 16) & 0o777;
     if (mode) {
       chmodSync(entryPath, mode);

--- a/src/file.ts
+++ b/src/file.ts
@@ -120,6 +120,8 @@ async function extractZipArchive(fromPath: string, toPath: string) {
 
   await zip.extract({ path: destinationPath });
 
+  // unzipper does not preserve Unix permissions stored in ZIP metadata.
+  // Restore them so scanner and JRE launchers remain executable.
   for (const entry of zip.files) {
     const entryPath = path.resolve(destinationPath, entry.path.replaceAll('\\', '/'));
     const mode = (entry.externalFileAttributes >>> 16) & 0o777;

--- a/src/file.ts
+++ b/src/file.ts
@@ -104,9 +104,6 @@ async function extractZipArchive(fromPath: string, toPath: string) {
   for (const entry of zip.files) {
     const entryPath = path.join(destinationPath, entry.path.replaceAll('\\', '/'));
     const relativePath = path.relative(destinationPath, entryPath);
-    if (relativePath === '') {
-      continue;
-    }
     if (
       relativePath === '..' ||
       relativePath.startsWith(`..${path.sep}`) ||

--- a/src/file.ts
+++ b/src/file.ts
@@ -92,35 +92,39 @@ export async function extractArchive(fromPath: string, toPath: string) {
 
     await extractionPromise;
   } else {
-    const destinationPath = path.resolve(toPath);
-    const zip = await unzipper.Open.file(fromPath);
+    await extractZipArchive(fromPath, toPath);
+  }
+}
 
-    for (const entry of zip.files) {
-      const entryPath = path.resolve(destinationPath, entry.path.replaceAll('\\', '/'));
-      const relativePath = path.relative(destinationPath, entryPath);
-      if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
-        throw new Error(`Entry "${entry.path}" would extract outside target directory`);
-      }
+async function extractZipArchive(fromPath: string, toPath: string) {
+  const destinationPath = path.resolve(toPath);
+  const zip = await unzipper.Open.file(fromPath);
 
-      for (
-        let currentPath = entryPath;
-        currentPath !== destinationPath;
-        currentPath = path.dirname(currentPath)
-      ) {
-        if (lstatSync(currentPath, { throwIfNoEntry: false })?.isSymbolicLink()) {
-          throw new Error(`Entry "${entry.path}" would extract through a symbolic link`);
-        }
-      }
+  for (const entry of zip.files) {
+    const entryPath = path.resolve(destinationPath, entry.path.replaceAll('\\', '/'));
+    const relativePath = path.relative(destinationPath, entryPath);
+    if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+      throw new Error(`Entry "${entry.path}" would extract outside target directory`);
     }
 
-    await zip.extract({ path: destinationPath });
-
-    for (const entry of zip.files) {
-      const entryPath = path.resolve(destinationPath, entry.path.replaceAll('\\', '/'));
-      const mode = (entry.externalFileAttributes >>> 16) & 0o777;
-      if (mode) {
-        chmodSync(entryPath, mode);
+    for (
+      let currentPath = entryPath;
+      currentPath !== destinationPath;
+      currentPath = path.dirname(currentPath)
+    ) {
+      if (lstatSync(currentPath, { throwIfNoEntry: false })?.isSymbolicLink()) {
+        throw new Error(`Entry "${entry.path}" would extract through a symbolic link`);
       }
+    }
+  }
+
+  await zip.extract({ path: destinationPath });
+
+  for (const entry of zip.files) {
+    const entryPath = path.resolve(destinationPath, entry.path.replaceAll('\\', '/'));
+    const mode = (entry.externalFileAttributes >>> 16) & 0o777;
+    if (mode) {
+      chmodSync(entryPath, mode);
     }
   }
 }

--- a/src/file.ts
+++ b/src/file.ts
@@ -14,10 +14,11 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-import AdmZip from 'adm-zip';
 import crypto from 'node:crypto';
+import { chmodSync, lstatSync } from 'node:fs';
 import path from 'node:path';
 import tarStream from 'tar-stream';
+import unzipper from 'unzipper';
 import zlib from 'node:zlib';
 import { SONAR_CACHE_DIR, UNARCHIVE_SUFFIX } from './constants.js';
 import { getDeps } from './deps.js';
@@ -91,18 +92,36 @@ export async function extractArchive(fromPath: string, toPath: string) {
 
     await extractionPromise;
   } else {
-    const zip = new AdmZip(fromPath);
+    const destinationPath = path.resolve(toPath);
+    const zip = await unzipper.Open.file(fromPath);
 
-    for (const entry of zip.getEntries()) {
-      const canonicalPath = path.normalize(toPath + path.sep + entry.entryName);
+    for (const entry of zip.files) {
+      const entryPath = path.resolve(destinationPath, entry.path.replaceAll('\\', '/'));
+      const relativePath = path.relative(destinationPath, entryPath);
+      if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+        throw new Error(`Entry "${entry.path}" would extract outside target directory`);
+      }
 
-      // Prevent Zip Slip vulnerability by ensuring the path is within the target directory
-      if (!canonicalPath.startsWith(toPath)) {
-        throw new Error(`Entry "${entry.entryName}" would extract outside target directory`);
+      for (
+        let currentPath = entryPath;
+        currentPath !== destinationPath;
+        currentPath = path.dirname(currentPath)
+      ) {
+        if (lstatSync(currentPath, { throwIfNoEntry: false })?.isSymbolicLink()) {
+          throw new Error(`Entry "${entry.path}" would extract through a symbolic link`);
+        }
       }
     }
 
-    zip.extractAllTo(toPath, true, true);
+    await zip.extract({ path: destinationPath });
+
+    for (const entry of zip.files) {
+      const entryPath = path.resolve(destinationPath, entry.path.replaceAll('\\', '/'));
+      const mode = (entry.externalFileAttributes >>> 16) & 0o777;
+      if (mode) {
+        chmodSync(entryPath, mode);
+      }
+    }
   }
 }
 

--- a/test/unit/file.test.ts
+++ b/test/unit/file.test.ts
@@ -16,6 +16,8 @@
  */
 import { describe, it, mock, afterEach } from 'node:test';
 import assert from 'node:assert';
+import nodeFs from 'node:fs';
+import nodeOs from 'node:os';
 import path from 'node:path';
 import { SONAR_CACHE_DIR } from '../../src/constants.js';
 import { setDeps, resetDeps } from '../../src/deps.js';
@@ -26,7 +28,7 @@ import {
   validateChecksum,
 } from '../../src/file.js';
 import { ScannerProperty } from '../../src/types.js';
-import { createMockFsDeps } from './test-helpers.js';
+import { createMockFsDeps, fixturePath } from './test-helpers.js';
 
 // Mock console.log to suppress output
 mock.method(console, 'log', () => {});
@@ -179,17 +181,45 @@ describe('file', () => {
 
   describe('extractArchive', () => {
     it('should extract a zip archive', async () => {
-      // Since extractArchive uses AdmZip directly (not through deps), we can't easily mock it
-      // But we can test that the function handles different file extensions correctly
-      // by checking that it throws for a non-existent zip file
+      const testDirectory = nodeFs.mkdtempSync(path.join(nodeOs.tmpdir(), 'extract-zip-'));
+      const destinationPath = path.join(testDirectory, 'destination');
+
       try {
-        await extractArchive('/nonexistent/file.zip', '/tmp/extract-test');
-        assert.fail('Expected an error');
-      } catch (e) {
-        // Expected to fail since file doesn't exist - this exercises the zip branch
-        assert.ok(e instanceof Error);
+        await extractArchive(fixturePath('webserver/executable.zip'), destinationPath);
+
+        const scannerPath = path.join(destinationPath, 'executable');
+        assert.strictEqual(nodeFs.readFileSync(scannerPath, 'utf8'), 'echo "hello"\n');
+        if (process.platform !== 'win32') {
+          assert.strictEqual(nodeFs.statSync(scannerPath).mode & 0o777, 0o755);
+        }
+      } finally {
+        nodeFs.rmSync(testDirectory, { recursive: true, force: true });
       }
     });
+
+    it(
+      'should not follow a pre-existing file symlink while extracting zip',
+      { skip: process.platform === 'win32' },
+      async () => {
+        const testDirectory = nodeFs.mkdtempSync(path.join(nodeOs.tmpdir(), 'zip-symlink-'));
+        const destinationPath = path.join(testDirectory, 'destination');
+        const outsidePath = path.join(testDirectory, 'outside.txt');
+        nodeFs.mkdirSync(destinationPath);
+        nodeFs.writeFileSync(outsidePath, 'outside');
+        nodeFs.symlinkSync(outsidePath, path.join(destinationPath, 'executable'));
+
+        try {
+          await assert.rejects(
+            extractArchive(fixturePath('webserver/executable.zip'), destinationPath),
+            { message: /would extract through a symbolic link/ },
+          );
+
+          assert.strictEqual(nodeFs.readFileSync(outsidePath, 'utf8'), 'outside');
+        } finally {
+          nodeFs.rmSync(testDirectory, { recursive: true, force: true });
+        }
+      },
+    );
 
     it('should reject tar.gz entries with path traversal (Zip Slip)', async () => {
       const tarStream = await import('tar-stream');

--- a/test/unit/file.test.ts
+++ b/test/unit/file.test.ts
@@ -221,6 +221,29 @@ describe('file', () => {
       },
     );
 
+    it('should reject zip entries with path traversal', async () => {
+      const testDirectory = nodeFs.mkdtempSync(path.join(nodeOs.tmpdir(), 'zip-slip-'));
+      const archivePath = path.join(testDirectory, 'archive.zip');
+      const archive = nodeFs.readFileSync(fixturePath('webserver/executable.zip'));
+
+      for (
+        let offset = archive.indexOf('executable');
+        offset !== -1;
+        offset = archive.indexOf('executable', offset + 1)
+      ) {
+        archive.write('../bad.txt', offset);
+      }
+      nodeFs.writeFileSync(archivePath, archive);
+
+      try {
+        await assert.rejects(extractArchive(archivePath, path.join(testDirectory, 'destination')), {
+          message: /would extract outside target directory/,
+        });
+      } finally {
+        nodeFs.rmSync(testDirectory, { recursive: true, force: true });
+      }
+    });
+
     it('should reject tar.gz entries with path traversal (Zip Slip)', async () => {
       const tarStream = await import('tar-stream');
       const zlib = await import('node:zlib');


### PR DESCRIPTION
Part of

## Summary

- replace adm-zip 0.6.0, which is affected by CVE-2026-76845, with unzipper 0.12.5
- reject ZIP extraction when an entry destination contains a pre-existing symbolic link
- preserve executable permissions provided by ZIP entries
- add a regression test proving extraction cannot overwrite a file outside the destination through a symlink

## Verification

- npm test (151 tests)
- npm run build
- npm run check-format
- npm audit --omit=dev --registry=https://registry.npmjs.org (0 vulnerabilities)
- git diff --check